### PR TITLE
bs-platform@7.0.1 update

### DIFF
--- a/packages/reason-expo/src/AR.re
+++ b/packages/reason-expo/src/AR.re
@@ -345,26 +345,25 @@ module TrackingStateReason = {
   external relocalizing: t = "Relocalizing";
 };
 
-[@bs.deriving abstract]
+
 type size = {
   width: float,
   height: float,
 };
 
-[@bs.deriving abstract]
+
 type vector3 = {
   x: float,
   y: float,
   z: float,
 };
 
-[@bs.deriving abstract]
 type vector2 = {
   x: float,
   y: float,
 };
 
-[@bs.deriving abstract]
+
 type textureCoordinate = {
   u: float,
   v: float,
@@ -372,7 +371,6 @@ type textureCoordinate = {
 
 type matrix = array(float);
 
-[@bs.deriving abstract]
 type faceGeometry = {
   vertexCount: float,
   textureCoordinateCount: float,
@@ -382,33 +380,26 @@ type faceGeometry = {
   triangleIndices: array(float),
 };
 
-[@bs.deriving abstract]
 type anchor = {
   [@bs.as "type"]
   type_: AnchorType.t,
   transform: matrix,
   id: string,
-  [@bs.optional]
-  center: vector3,
-  [@bs.optional]
-  extent: {
-    .
-    width: float,
-    length: float,
-  },
-  [@bs.optional]
-  image: {
-    .
-    name: string,
-    size: size,
-  },
-  [@bs.optional]
-  geometry: faceGeometry,
-  [@bs.optional]
-  blendShapes: Js.Dict.t(float),
+  center: option(vector3),
+  extent: option(extent),
+  image: option(image),
+  geometry: option(faceGeometry),
+  blendShapes: option(Js.Dict.t(float)),
+}
+and image = {
+  name: string,
+  size,
+}
+and extent = {
+  width: float,
+  length: float,
 };
 
-[@bs.deriving abstract]
 type hitTest = {
   [@bs.as "type"]
   type_: float,
@@ -418,50 +409,42 @@ type hitTest = {
   anchor,
 };
 
-[@bs.deriving abstract]
 type hitTestResults = {hitTest};
 
-[@bs.deriving abstract]
 type detectionImage = {
   uri: string,
   width: float,
-  [@bs.optional]
-  name: string,
+  name: option(string),
 };
 
-[@bs.deriving abstract]
 type arFrameAnchorRequest = {
-  [@bs.as "ARFaceTrackingConfiguration"] [@bs.optional]
-  arFaceTrackingConfiguration: {
-    .
-    geometry: bool,
-    blendShapes: array(BlendShape.t),
-  },
+  [@bs.as "ARFaceTrackingConfiguration"]
+  arFaceTrackingConfiguration: option(arFaceTrackingConfiguration),
+}
+and arFaceTrackingConfiguration = {
+  geometry: bool,
+  blendShapes: array(BlendShape.t),
 };
 
-[@bs.deriving abstract]
+
 type arFrameRequest = {
-  [@bs.optional]
-  anchors: arFrameAnchorRequest,
-  [@bs.optional]
-  rawFeaturePoints: bool,
-  [@bs.optional]
-  lightEstimation: bool,
-  [@bs.optional]
-  capturedDepthData: bool,
+  // [@bs.optional]
+  anchors: option(arFrameAnchorRequest),
+  // [@bs.optional]
+  rawFeaturePoints: option(bool),
+  // [@bs.optional]
+  lightEstimation: option(bool),
+  // [@bs.optional]
+  capturedDepthData: option(bool),
 };
 
-[@bs.deriving abstract]
 type lightEstimation = {
   ambientIntensity: float,
   ambientColorTemperature: float,
-  [@bs.optional]
-  primaryLightDirection: vector3,
-  [@bs.optional]
-  primaryLightIntensity: float,
+  primaryLightDirection: option(vector3),
+  primaryLightIntensity: option(float),
 };
 
-[@bs.deriving abstract]
 type rawFeaturePoint = {
   x: float,
   y: float,
@@ -469,7 +452,6 @@ type rawFeaturePoint = {
   id: string,
 };
 
-[@bs.deriving abstract]
 type cameraCalibrationData(
   'lensDistortionLookupTable,
   'inverseLensDistortionLookupTable,
@@ -483,7 +465,6 @@ type cameraCalibrationData(
   lensDistortionCenter: vector3,
 };
 
-[@bs.deriving abstract]
 type capturedDepthData = {
   timestamp: float,
   depthDataQuality: DepthDataQuality.t,
@@ -492,36 +473,28 @@ type capturedDepthData = {
   cameraCalibrationData: cameraCalibrationData(string, string),
 };
 
-[@bs.deriving abstract]
+
 type arFrame = {
   timestamp: float,
-  [@bs.optional]
-  anchors: array(anchor),
-  [@bs.optional]
-  rawFeaturePoints: array(rawFeaturePoint),
-  [@bs.optional]
-  lightEstimation,
-  [@bs.optional]
-  capturedDepthData,
+  anchors: option(array(anchor)),
+  rawFeaturePoints: option(array(rawFeaturePoint)),
+  lightEstimation:option(lightEstimation),
+  capturedDepthData:option(capturedDepthData),
 };
 
-[@bs.deriving abstract]
 type arMatrices = {
   transform: matrix,
   viewMatrix: matrix,
   projectionMatrix: matrix,
 };
 
-[@bs.deriving abstract]
 type arStartResult = {capturedImageTexture: float};
 
-[@bs.deriving abstract]
 type imageResolution = {
   width: float,
   height: float,
 };
 
-[@bs.deriving abstract]
 type videoFormat = {
   [@bs.as "type"]
   type_: string,
@@ -529,18 +502,21 @@ type videoFormat = {
   framesPerSecond: float,
 };
 
-[@bs.module "expo"] [@bs.scope "AR"] external isAvailable: unit => bool = "";
-
-[@bs.module "expo"] [@bs.scope "AR"] external getVersion: unit => string = "";
+[@bs.module "expo"] [@bs.scope "AR"]
+external isAvailable: unit => bool = "isAvailable";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external removeAllListeners: EventType.t => unit = "";
+external getVersion: unit => string = "getVersion";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external onFrameDidUpdate: (unit => unit) => unit = "";
+external removeAllListeners: EventType.t => unit = "removeAllListeners";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external onDidFailWithError: ({. error: string} => unit) => unit = "";
+external onFrameDidUpdate: (unit => unit) => unit = "onFrameDidUpdate";
+
+[@bs.module "expo"] [@bs.scope "AR"]
+external onDidFailWithError: ({. error: string} => unit) => unit =
+  "onDidFailWithError";
 
 [@bs.module "expo"] [@bs.scope "AR"]
 external onAnchorsDidUpdate:
@@ -553,7 +529,7 @@ external onAnchorsDidUpdate:
     unit
   ) =>
   unit =
-  "";
+  "onAnchorsDidUpdate";
 
 [@bs.module "expo"] [@bs.scope "AR"]
 external onCameraDidChangeTrackingState:
@@ -566,13 +542,15 @@ external onCameraDidChangeTrackingState:
     unit
   ) =>
   unit =
-  "";
+  "onCameraDidChangeTrackingState";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external onSessionWasInterrupted: (unit => unit) => unit = "";
+external onSessionWasInterrupted: (unit => unit) => unit =
+  "onSessionWasInterrupted";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external onSessionInterruptionEnded: (unit => unit) => unit = "";
+external onSessionInterruptionEnded: (unit => unit) => unit =
+  "onSessionInterruptionEnded";
 
 [@bs.module "expo"] [@bs.scope "AR"]
 external performHitTest:
@@ -585,83 +563,85 @@ external performHitTest:
     HitTestResultTypes.t
   ) =>
   hitTestResults =
-  "";
+  "performHitTest";
 
 [@bs.module "expo"] [@bs.scope "AR"]
 external setDetectionImagesAsync:
   Js.Dict.t(detectionImage) => Js.Promise.t(unit) =
-  "";
+  "setDetectionImagesAsync";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external getCurrentFrame: arFrameRequest => Js.Nullable.t(arFrame) = "";
+external getCurrentFrame: arFrameRequest => Js.Nullable.t(arFrame) =
+  "getCurrentFrame";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external getARMatrices: (float, float) => array(arMatrices) = "";
+external getARMatrices: (float, float) => array(arMatrices) = "getARMatrices";
 
 [@bs.module "expo"] [@bs.scope "AR"]
 external startAsync:
   (React.Ref.t(React.element), TrackingConfiguration.t) => Js.Promise.t(unit) =
-  "";
+  "startAsync";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external stopAsync: unit => Js.Promise.t(unit) = "";
+external stopAsync: unit => Js.Promise.t(unit) = "stopAsync";
 
-[@bs.module "expo"] [@bs.scope "AR"] external reset: unit => unit = "";
+[@bs.module "expo"] [@bs.scope "AR"] external reset: unit => unit = "reset";
 
-[@bs.module "expo"] [@bs.scope "AR"] external pause: unit => unit = "";
+[@bs.module "expo"] [@bs.scope "AR"] external pause: unit => unit = "pause";
 
-[@bs.module "expo"] [@bs.scope "AR"] external resume: unit => unit = "";
+[@bs.module "expo"] [@bs.scope "AR"] external resume: unit => unit = "resume";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external isConfigurationAvailable: TrackingConfiguration.t => bool = "";
+external isConfigurationAvailable: TrackingConfiguration.t => bool =
+  "isConfigurationAvailable";
 
 [@bs.module "expo"] [@bs.scope "AR"]
 external setConfigurationAsync: TrackingConfiguration.t => Js.Promise.t(unit) =
-  "";
+  "setConfigurationAsync";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external isFrontCameraAvailable: unit => bool = "";
+external isFrontCameraAvailable: unit => bool = "isFrontCameraAvailable";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external isRearCameraAvailable: unit => bool = "";
+external isRearCameraAvailable: unit => bool = "isRearCameraAvailable";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external planeDetection: unit => PlaneDetection.t = "";
+external planeDetection: unit => PlaneDetection.t = "planeDetection";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external setPlaneDetection: PlaneDetection.t => unit = "";
+external setPlaneDetection: PlaneDetection.t => unit = "setPlaneDetection";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external setWorldOriginAsync: matrix => unit = "";
+external setWorldOriginAsync: matrix => unit = "setWorldOriginAsync";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external setLightEstimationEnabled: bool => unit = "";
+external setLightEstimationEnabled: bool => unit = "setLightEstimationEnabled";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external getLightEstimationEnabled: unit => bool = "";
+external getLightEstimationEnabled: unit => bool = "getLightEstimationEnabled";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external setProvidesAudioData: bool => unit = "";
+external setProvidesAudioData: bool => unit = "setProvidesAudioData";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external getProvidesAudioData: unit => bool = "";
+external getProvidesAudioData: unit => bool = "getProvidesAudioData";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external setAutoFocusEnabled: bool => unit = "";
+external setAutoFocusEnabled: bool => unit = "setAutoFocusEnabled";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external getAutoFocusEnabled: unit => bool = "";
+external getAutoFocusEnabled: unit => bool = "getAutoFocusEnabled";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external setWorldAlignment: WorldAlignment.t => unit = "";
+external setWorldAlignment: WorldAlignment.t => unit = "setWorldAlignment";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external getWorldAlignment: unit => WorldAlignment.t = "";
+external getWorldAlignment: unit => WorldAlignment.t = "getWorldAlignment";
 
 [@bs.module "expo"] [@bs.scope "AR"]
-external getCameraTexture: unit => float = "";
+external getCameraTexture: unit => float = "getCameraTexture";
 
 [@bs.module "expo"] [@bs.scope "AR"]
 external getSupportedVideoFormats:
   TrackingConfiguration.t => array(videoFormat) =
-  "";
+  "getSupportedVideoFormats";

--- a/packages/reason-expo/src/AR.re
+++ b/packages/reason-expo/src/AR.re
@@ -428,13 +428,13 @@ and arFaceTrackingConfiguration = {
 
 
 type arFrameRequest = {
-  // [@bs.optional]
+
   anchors: option(arFrameAnchorRequest),
-  // [@bs.optional]
+
   rawFeaturePoints: option(bool),
-  // [@bs.optional]
+
   lightEstimation: option(bool),
-  // [@bs.optional]
+
   capturedDepthData: option(bool),
 };
 

--- a/packages/reason-expo/src/Accelerometer.re
+++ b/packages/reason-expo/src/Accelerometer.re
@@ -1,9 +1,8 @@
-[@bs.deriving abstract]
+
 type eventSubscription;
 
 [@bs.send] external remove: (eventSubscription, unit) => unit = "remove";
 
-[@bs.deriving abstract]
 type location = {
   x: int,
   y: int,

--- a/packages/reason-expo/src/AdMob.re
+++ b/packages/reason-expo/src/AdMob.re
@@ -9,21 +9,21 @@ type bannerSize =
 
 module AdMobBanner = {
   type props = {
-    // [@bs.optional]
+
     bannerSize: option(string),
-    // [@bs.optional]
+
     onAdViewDidReceiveAd: option(unit => unit),
-    // [@bs.optional]
+
     onDidFailToReceiveAdWithError: option(string => unit),
-    // [@bs.optional]
+
     onAdViewWillPresentScreen: option(unit => unit),
-    // [@bs.optional]
+
     onAdViewWillDismissScreen: option(unit => unit),
-    // [@bs.optional]
+
     onAdViewDidDismissScreen: option(unit => unit),
-    // [@bs.optional]
+
     onAdViewWillLeaveApplication: option(unit => unit),
-    // [@bs.optional]
+
     children: option(React.element),
   };
 

--- a/packages/reason-expo/src/AdMob.re
+++ b/packages/reason-expo/src/AdMob.re
@@ -8,27 +8,26 @@ type bannerSize =
   | SmartBannerLandscape;
 
 module AdMobBanner = {
-  [@bs.deriving abstract]
   type props = {
-    [@bs.optional]
-    bannerSize: string,
-    [@bs.optional]
-    onAdViewDidReceiveAd: unit => unit,
-    [@bs.optional]
-    onDidFailToReceiveAdWithError: string => unit,
-    [@bs.optional]
-    onAdViewWillPresentScreen: unit => unit,
-    [@bs.optional]
-    onAdViewWillDismissScreen: unit => unit,
-    [@bs.optional]
-    onAdViewDidDismissScreen: unit => unit,
-    [@bs.optional]
-    onAdViewWillLeaveApplication: unit => unit,
-    [@bs.optional]
-    children: React.element,
+    // [@bs.optional]
+    bannerSize: option(string),
+    // [@bs.optional]
+    onAdViewDidReceiveAd: option(unit => unit),
+    // [@bs.optional]
+    onDidFailToReceiveAdWithError: option(string => unit),
+    // [@bs.optional]
+    onAdViewWillPresentScreen: option(unit => unit),
+    // [@bs.optional]
+    onAdViewWillDismissScreen: option(unit => unit),
+    // [@bs.optional]
+    onAdViewDidDismissScreen: option(unit => unit),
+    // [@bs.optional]
+    onAdViewWillLeaveApplication: option(unit => unit),
+    // [@bs.optional]
+    children: option(React.element),
   };
 
-  let makeProps =
+  let props =
       (
         ~bannerSize=Banner,
         ~onAdViewDidReceiveAd=() => (),
@@ -38,26 +37,25 @@ module AdMobBanner = {
         ~onAdViewDidDismissScreen=() => (),
         ~onAdViewWillLeaveApplication=() => (),
         ~children,
-      ) =>
-    props(
-      ~bannerSize=
-        switch (bannerSize) {
-        | Banner => "banner"
-        | LargeBanner => "largeBanner"
-        | MediumRectangle => "mediumRectangle"
-        | FullBanner => "fullBanner"
-        | Leaderboard => "leaderboard"
-        | SmartBannerPortrait => "smartBannerPortrait"
-        | SmartBannerLandscape => "smartBannerLandscape"
-        },
-      ~onAdViewDidReceiveAd,
-      ~onDidFailToReceiveAdWithError,
-      ~onAdViewWillPresentScreen,
-      ~onAdViewWillDismissScreen,
-      ~onAdViewDidDismissScreen,
-      ~onAdViewWillLeaveApplication,
-      ~children,
-    );
+      ) => {
+    bannerSize:
+      switch (bannerSize) {
+      | Banner => Some("banner")
+      | LargeBanner => Some("largeBanner")
+      | MediumRectangle => Some("mediumRectangle")
+      | FullBanner => Some("fullBanner")
+      | Leaderboard => Some("leaderboard")
+      | SmartBannerPortrait => Some("smartBannerPortrait")
+      | SmartBannerLandscape => Some("smartBannerLandscape")
+      },
+    onAdViewDidReceiveAd: Some(onAdViewDidReceiveAd),
+    onDidFailToReceiveAdWithError: Some(onDidFailToReceiveAdWithError),
+    onAdViewWillPresentScreen: Some(onAdViewWillPresentScreen),
+    onAdViewWillDismissScreen: Some(onAdViewWillDismissScreen),
+    onAdViewDidDismissScreen: Some(onAdViewDidDismissScreen),
+    onAdViewWillLeaveApplication: Some(onAdViewWillLeaveApplication),
+    children: Some(children),
+  };
 
   [@bs.module "expo-ads-admob"] [@react.component]
   external make: props => React.element = "AdMobBanner";

--- a/packages/reason-expo/src/Asset.re
+++ b/packages/reason-expo/src/Asset.re
@@ -1,4 +1,3 @@
-[@bs.deriving abstract]
 type t = {
   name: string,
   [@bs.as "type"]

--- a/packages/reason-expo/src/Audio.re
+++ b/packages/reason-expo/src/Audio.re
@@ -1,5 +1,5 @@
 [@bs.module "expo-av"] [@bs.scope "Audio"]
-external setIsEnabledAsync: bool => Js.Promise.t(unit) = "";
+external setIsEnabledAsync: bool => Js.Promise.t(unit) = "setIsEnabledAsync";
 
 module InterruptionMode = {
   module IOS = {
@@ -26,7 +26,6 @@ module InterruptionMode = {
   };
 };
 
-[@bs.deriving abstract]
 type audioMode = {
   playsInSilentModeIOS: bool,
   allowsRecordingIOS: bool,
@@ -37,7 +36,7 @@ type audioMode = {
 };
 
 [@bs.module "expo-av"] [@bs.scope "Audio"]
-external setAudioModeAsync: audioMode => Js.Promise.t(unit) = "";
+external setAudioModeAsync: audioMode => Js.Promise.t(unit) = "setAudioModeAsync";
 
 module Source = {
   type t = [
@@ -100,7 +99,6 @@ module Sound = {
 };
 
 module Recording = {
-  [@bs.deriving abstract]
   type status = {
     canRecord: bool,
     isDoneRecording: bool,

--- a/packages/reason-expo/src/AuthSession.re
+++ b/packages/reason-expo/src/AuthSession.re
@@ -1,32 +1,37 @@
 /*
- Usage:
+  Usage:
 
- [@bs.deriving abstract]
- type paramsType = {token: string};
+  [@bs.deriving abstract]
+  type paramsType = {token: string};
 
- [@bs.deriving abstract]
- type eventType = {code: string};
+  [@bs.deriving abstract]
+  type eventType = {code: string};
 
  let x: Js.Promise.t(result(paramsType, eventType)) = startAsync(options(~authUrl="", ()));
+
+  */
+/*
+ New Usage:
+
+ type paramsType = {token: string};
+
+ type eventType = {code: string};
+
+let x: Js.Promise.t(result(paramsType, eventType)) =
+  startAsync({authUrl: "", returnUrl: None});
  */
 
-[@bs.deriving abstract]
 type options = {
   authUrl: string,
-  [@bs.optional]
-  returnUrl: string,
+  returnUrl: option(string),
 };
 
-[@bs.deriving abstract]
 type result('paramType, 'eventType) = {
   [@bs.as "type"]
   _type: string,
-  [@bs.optional]
-  params: 'paramType,
-  [@bs.optional]
-  event: 'eventType,
-  [@bs.optional]
-  errorCode: string,
+  params: option('paramType),
+  event: option('eventType),
+  errorCode: option(string),
 };
 
 [@bs.module "expo"] [@bs.scope "AuthSession"]

--- a/packages/reason-expo/src/BackgroundFetch.re
+++ b/packages/reason-expo/src/BackgroundFetch.re
@@ -25,13 +25,13 @@ module Result = {
 };
 
 [@bs.module "expo-background-fetch"]
-external getStatusAsync: unit => Js.Promise.t(Status.t) = "";
+external getStatusAsync: unit => Js.Promise.t(Status.t) = "getStatusAsync";
 
 [@bs.module "expo-background-fetch"]
-external registerTaskAsync: string => Js.Promise.t(unit) = "";
+external registerTaskAsync: string => Js.Promise.t(unit) = "registerTaskAsync";
 
 [@bs.module "expo-background-fetch"]
-external unregisterTaskAsync: string => Js.Promise.t(unit) = "";
+external unregisterTaskAsync: string => Js.Promise.t(unit) = "unregisterTaskAsync";
 
 [@bs.module "expo-background-fetch"]
-external setMinimumIntervalAsync: float => Js.Promise.t(unit) = "";
+external setMinimumIntervalAsync: float => Js.Promise.t(unit) = "setMinimumIntervalAsync";

--- a/packages/reason-expo/src/BarCodeScanner.re
+++ b/packages/reason-expo/src/BarCodeScanner.re
@@ -6,29 +6,24 @@ type torchMode =
   | On
   | Off;
 
-// [@bs.deriving abstract]
 type onBarCodeScannedResult = {
   [@bs.as "type"]
   _type: string,
   data: string,
 };
 
-// [@bs.deriving abstract]
 type barCodeScannerSettings = {
   barCodeTypes: array(string),
   useCamera2Api: bool,
 };
 
-// [@bs.deriving abstract]
 type props = {
   onBarCodeScanned: onBarCodeScannedResult => unit,
   [@bs.as "type"]
   _type: string,
   torchMode: string,
-  // [@bs.optional]
   barCodeScannerSettings: Js.Nullable.t(barCodeScannerSettings),
   style: ReactNative.Style.t,
-  // [@bs.optional]
   children: React.element,
 };
 

--- a/packages/reason-expo/src/BarCodeScanner.re
+++ b/packages/reason-expo/src/BarCodeScanner.re
@@ -6,33 +6,33 @@ type torchMode =
   | On
   | Off;
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type onBarCodeScannedResult = {
   [@bs.as "type"]
   _type: string,
   data: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type barCodeScannerSettings = {
   barCodeTypes: array(string),
   useCamera2Api: bool,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type props = {
   onBarCodeScanned: onBarCodeScannedResult => unit,
   [@bs.as "type"]
   _type: string,
   torchMode: string,
-  [@bs.optional]
+  // [@bs.optional]
   barCodeScannerSettings: Js.Nullable.t(barCodeScannerSettings),
   style: ReactNative.Style.t,
-  [@bs.optional]
+  // [@bs.optional]
   children: React.element,
 };
 
-let makeProps =
+let props =
     (
       ~onBarCodeScanned,
       ~type_=Back,
@@ -40,23 +40,22 @@ let makeProps =
       ~barCodeScannerSettings=?,
       ~style=ReactNative.Style.style(),
       ~children,
-    ) =>
-  props(
-    ~onBarCodeScanned,
-    ~_type=
-      switch (type_) {
-      | Front => "front"
-      | Back => "back"
-      },
-    ~torchMode=
-      switch (torchMode) {
-      | On => "on"
-      | Off => "off"
-      },
-    ~barCodeScannerSettings=Js.Nullable.fromOption(barCodeScannerSettings),
-    ~style,
-    ~children,
-  );
+    ) => {
+  onBarCodeScanned,
+  _type:
+    switch (type_) {
+    | Front => "front"
+    | Back => "back"
+    },
+  torchMode:
+    switch (torchMode) {
+    | On => "on"
+    | Off => "off"
+    },
+  barCodeScannerSettings: Js.Nullable.fromOption(barCodeScannerSettings),
+  style,
+  children,
+};
 
 [@bs.module "expo-barcode-scanner"] [@react.component]
 external make: props => React.element = "BarCodeScanner";

--- a/packages/reason-expo/src/Calendar.re
+++ b/packages/reason-expo/src/Calendar.re
@@ -234,14 +234,14 @@ module SourceType = {
   external birthdays: t = "BIRTHDAYS";
 };
 
-// [@bs.deriving abstract]
+
 type alarm = {
   absoluteDate: Js.Date.t,
   relativeOffset: int,
   method: AlarmMethod.t,
 };
 
-// [@bs.deriving abstract]
+
 type recurrenceRule = {
   frequency: Frequency.t,
   interval: int,
@@ -249,7 +249,7 @@ type recurrenceRule = {
   occurrence: int,
 };
 
-// [@bs.deriving abstract]
+
 type attendee = {
   id: string,
   email: string,
@@ -271,7 +271,7 @@ type attendee = {
       _type: string,
     } */
 
-// [@bs.deriving abstract]
+
 type source = {
   id: string,
   name: string,
@@ -280,7 +280,7 @@ type source = {
   isLocalAccount: bool,
 };
 
-// [@bs.deriving abstract]
+
 type calendar = {
   id: string,
   title: string,
@@ -302,7 +302,7 @@ type calendar = {
   accessLevel: CalendarAccessLevel.t,
 };
 
-// [@bs.deriving abstract]
+
 type event = {
   id: string,
   calendarId: string,
@@ -333,7 +333,7 @@ type event = {
   instanceId: string,
 };
 
-// [@bs.deriving abstract]
+
 type reminder = {
   id: string,
   calendarId: string,
@@ -356,7 +356,7 @@ type reminder = {
 external getCalendarsAsync: EntityType.t => Js.Promise.t(array(calendar)) =
   "getCalendarsAsync";
 
-// [@bs.deriving abstract]
+
 type createCalendarAsyncDetails = {
   title: string,
   color: string,
@@ -370,19 +370,19 @@ type createCalendarAsyncDetails = {
   },
   name: string,
   ownerAccount: string,
-  // [@bs.optional]
+
   timeZone: option(string),
-  // [@bs.optional]
+
   allowedAvailabilities: option(array(Availability.t)),
-  // [@bs.optional]
+
   allowedReminders: option(array(AlarmMethod.t)),
-  // [@bs.optional]
+
   allowedAttendeeTypes: option(array(AttendeeType.t)),
-  // [@bs.optional]
+
   isVisible: option(bool),
-  // [@bs.optional]
+
   isSynced: option(bool),
-  // [@bs.optional]
+
   accessLevel: string,
 };
 
@@ -391,7 +391,7 @@ external createCalendarAsync:
   createCalendarAsyncDetails => Js.Promise.t(string) =
   "createCalendarAsync";
 
-// [@bs.deriving abstract]
+
 type updateCalendarAsyncDetails = {
   title: Js.Nullable.t(string),
   color: Js.Nullable.t(string),
@@ -415,7 +415,7 @@ external getEventAsync:
   (string, {. instanceStartDate: Js.Date.t}) => Js.Promise.t(event) =
   "getEventAsync";
 
-// [@bs.deriving abstract]
+
 type createEventAsyncDetails = {
   title: string,
   startDate: Js.Date.t,
@@ -441,7 +441,7 @@ external createEventAsync:
   (string, createEventAsyncDetails) => Js.Promise.t(string) =
   "createEventAsync";
 
-// [@bs.deriving abstract]
+
 type updateEventAsyncDetails = {
   title: string,
   startDate: Js.Date.t,

--- a/packages/reason-expo/src/Calendar.re
+++ b/packages/reason-expo/src/Calendar.re
@@ -234,14 +234,14 @@ module SourceType = {
   external birthdays: t = "BIRTHDAYS";
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type alarm = {
   absoluteDate: Js.Date.t,
   relativeOffset: int,
   method: AlarmMethod.t,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type recurrenceRule = {
   frequency: Frequency.t,
   interval: int,
@@ -249,7 +249,7 @@ type recurrenceRule = {
   occurrence: int,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type attendee = {
   id: string,
   email: string,
@@ -258,11 +258,20 @@ type attendee = {
   status: AttendeeStatus.t,
   [@bs.as "type"]
   _type: string,
-  url: string,
-  isCurrentUser: bool,
+  url: option(string),
+  isCurrentUser: option(bool),
 };
+/* {
+      .
+      id: string,
+      email: string,
+      name: string,
+      role: AttendeeRole.t,
+      status: AttendeeStatus.t,
+      _type: string,
+    } */
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type source = {
   id: string,
   name: string,
@@ -271,7 +280,7 @@ type source = {
   isLocalAccount: bool,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type calendar = {
   id: string,
   title: string,
@@ -293,7 +302,7 @@ type calendar = {
   accessLevel: CalendarAccessLevel.t,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type event = {
   id: string,
   calendarId: string,
@@ -324,7 +333,7 @@ type event = {
   instanceId: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type reminder = {
   id: string,
   calendarId: string,
@@ -345,9 +354,9 @@ type reminder = {
 
 [@bs.module "expo-calendar"]
 external getCalendarsAsync: EntityType.t => Js.Promise.t(array(calendar)) =
-  "";
+  "getCalendarsAsync";
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type createCalendarAsyncDetails = {
   title: string,
   color: string,
@@ -361,28 +370,28 @@ type createCalendarAsyncDetails = {
   },
   name: string,
   ownerAccount: string,
-  [@bs.optional]
-  timeZone: string,
-  [@bs.optional]
-  allowedAvailabilities: array(Availability.t),
-  [@bs.optional]
-  allowedReminders: array(AlarmMethod.t),
-  [@bs.optional]
-  allowedAttendeeTypes: array(AttendeeType.t),
-  [@bs.optional]
-  isVisible: bool,
-  [@bs.optional]
-  isSynced: bool,
-  [@bs.optional]
+  // [@bs.optional]
+  timeZone: option(string),
+  // [@bs.optional]
+  allowedAvailabilities: option(array(Availability.t)),
+  // [@bs.optional]
+  allowedReminders: option(array(AlarmMethod.t)),
+  // [@bs.optional]
+  allowedAttendeeTypes: option(array(AttendeeType.t)),
+  // [@bs.optional]
+  isVisible: option(bool),
+  // [@bs.optional]
+  isSynced: option(bool),
+  // [@bs.optional]
   accessLevel: string,
 };
 
 [@bs.module "expo-calendar"]
 external createCalendarAsync:
   createCalendarAsyncDetails => Js.Promise.t(string) =
-  "";
+  "createCalendarAsync";
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type updateCalendarAsyncDetails = {
   title: Js.Nullable.t(string),
   color: Js.Nullable.t(string),
@@ -394,19 +403,19 @@ type updateCalendarAsyncDetails = {
 [@bs.module "expo-calendar"]
 external updateCalendarAsync:
   (string, updateCalendarAsyncDetails) => Js.Promise.t(unit) =
-  "";
+  "updateCalendarAsync";
 
 [@bs.module "expo-calendar"]
 external getEventsAsync:
   (array(string), Js.Date.t, Js.Date.t) => Js.Promise.t(array(event)) =
-  "";
+  "updateCalendarAsync";
 
 [@bs.module "expo-calendar"]
 external getEventAsync:
   (string, {. instanceStartDate: Js.Date.t}) => Js.Promise.t(event) =
-  "";
+  "getEventAsync";
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type createEventAsyncDetails = {
   title: string,
   startDate: Js.Date.t,
@@ -430,9 +439,9 @@ type createEventAsyncDetails = {
 [@bs.module "expo-calendar"]
 external createEventAsync:
   (string, createEventAsyncDetails) => Js.Promise.t(string) =
-  "";
+  "createEventAsync";
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type updateEventAsyncDetails = {
   title: string,
   startDate: Js.Date.t,
@@ -452,56 +461,43 @@ type updateEventAsyncDetails = {
   guestsCanInviteOthers: bool,
   guestsCanSeeGuests: bool,
 };
+type instanceStartDate = Js.Date.t;
+type futureEvents = {
+  instanceStartDate,
+  futureEvents: bool,
+};
+type updateEventAsyncProps = {
+  string,
+  updateEventAsyncDetails,
+  futureEvents,
+};
+type deleteEventAsyncProps = {
+  string,
+  futureEvents,
+};
 
 [@bs.module "expo-calendar"]
-external updateEventAsync:
-  (
-    string,
-    updateEventAsyncDetails,
-    {
-      .
-      instanceStartDate: Js.Date.t,
-      futureEvents: bool,
-    }
-  ) =>
-  Js.Promise.t(unit) =
-  "";
+external updateEventAsync: updateEventAsyncProps => Js.Promise.t(unit) =
+  "updateEventAsync";
 
 [@bs.module "expo-calendar"]
-external deleteEventAsync:
-  (
-    string,
-    {
-      .
-      instanceStartDate: Js.Date.t,
-      futureEvents: bool,
-    }
-  ) =>
-  Js.Promise.t(unit) =
-  "";
+external deleteEventAsync: deleteEventAsyncProps => Js.Promise.t(unit) =
+  "deleteEventAsync";
 
 [@bs.module "expo-calendar"]
 external getAttendeesForEventAsync:
-  (string, {. instanceStartDate: Js.Date.t}) =>
+  (string, instanceStartDate) =>
   Js.Promise.t(array(attendee)) =
-  "";
+  "getAttendeesForEventAsync";
 
 [@bs.module "expo-calendar"]
 external createAttendeeAsync:
   (
     string,
-    {
-      .
-      id: string,
-      email: string,
-      name: string,
-      role: AttendeeRole.t,
-      status: AttendeeStatus.t,
-      _type: string,
-    }
+    attendee
   ) =>
   Js.Promise.t(string) =
-  "";
+  "createAttendeeAsync";
 
 [@bs.module "expo-calendar"]
 external updateAttendeeAsync:
@@ -518,19 +514,21 @@ external updateAttendeeAsync:
     }
   ) =>
   Js.Promise.t(unit) =
-  "";
+  "updateAttendeeAsync";
 
 [@bs.module "expo-calendar"]
-external deleteAttendeeAsync: string => Js.Promise.t(unit) = "";
+external deleteAttendeeAsync: string => Js.Promise.t(unit) =
+  "deleteAttendeeAsync";
 
 [@bs.module "expo-calendar"]
 external getRemindersAsync:
   (array(string), string, Js.Date.t, Js.Date.t) =>
   Js.Promise.t(array(reminder)) =
-  "";
+  "getRemindersAsync";
 
 [@bs.module "expo-calendar"]
-external getReminderAsync: string => Js.Promise.t(reminder) = "";
+external getReminderAsync: string => Js.Promise.t(reminder) =
+  "getReminderAsync";
 
 [@bs.module "expo-calendar"]
 external createReminderAsync:
@@ -552,7 +550,7 @@ external createReminderAsync:
     }
   ) =>
   Js.Promise.t(string) =
-  "";
+  "createReminderAsync";
 
 [@bs.module "expo-calendar"]
 external updateReminderAsync:
@@ -574,15 +572,18 @@ external updateReminderAsync:
     }
   ) =>
   Js.Promise.t(string) =
-  "";
+  "updateReminderAsync";
 
 [@bs.module "expo-calendar"]
-external deleteReminderAsync: string => Js.Promise.t(unit) = "";
+external deleteReminderAsync: string => Js.Promise.t(unit) =
+  "deleteReminderAsync";
 
 [@bs.module "expo-calendar"]
-external getSourcesAsync: unit => Js.Promise.t(array(source)) = "";
+external getSourcesAsync: unit => Js.Promise.t(array(source)) =
+  "getSourcesAsync";
 
 [@bs.module "expo-calendar"]
-external getSourceAsync: string => Js.Promise.t(source) = "";
+external getSourceAsync: string => Js.Promise.t(source) = "getSourceAsync";
 
-[@bs.module "expo-calendar"] external openEventInCalendar: string => unit = "";
+[@bs.module "expo-calendar"]
+external openEventInCalendar: string => unit = "openEventInCalendar";

--- a/packages/reason-expo/src/Camera.re
+++ b/packages/reason-expo/src/Camera.re
@@ -106,76 +106,75 @@ type whiteBalanceType =
   | Incandescent;
 
 type face = {
-  .
   faceID: int,
-  bounds: {
-    .
-    origin: {
-      .
-      x: float,
-      y: float,
-    },
-    size: {
-      .
-      width: float,
-      height: float,
-    },
-    rollAngle: float,
-    yawAngle: float,
-    smilingProbability: Js.nullable(float),
-    leftEarPosition: {
-      .
-      x: float,
-      y: float,
-    },
-    rightEarPosition: {
-      .
-      x: float,
-      y: float,
-    },
-    leftEyePosition: {
-      .
-      x: float,
-      y: float,
-    },
-    leftEyeOpenProbability: Js.nullable(float),
-    rightEyePosition: {
-      .
-      x: float,
-      y: float,
-    },
-    rightEyeOpenProbability: Js.nullable(float),
-    leftCheekPosition: {
-      .
-      x: float,
-      y: float,
-    },
-    rightCheekPosition: {
-      .
-      x: float,
-      y: float,
-    },
-    mouthPosition: {
-      .
-      x: float,
-      y: float,
-    },
-    leftMouthPosition: {
-      .
-      x: float,
-      y: float,
-    },
-    rightMouthPosition: {
-      .
-      x: float,
-      y: float,
-    },
-    noseBasePosition: {
-      .
-      x: float,
-      y: float,
-    },
-  },
+  bounds,
+}
+and bounds = {
+  origin,
+  size,
+  rollAngle: float,
+  yawAngle: float,
+  smilingProbability: Js.nullable(float),
+  leftEarPosition,
+  rightEarPosition,
+  leftEyePosition,
+  leftEyeOpenProbability: Js.nullable(float),
+  rightEyePosition,
+  rightEyeOpenProbability: Js.nullable(float),
+  leftCheekPosition,
+  rightCheekPosition,
+  mouthPosition,
+  leftMouthPosition,
+  rightMouthPosition,
+  noseBasePosition,
+}
+and origin = {
+  x: float,
+  y: float,
+}
+and size = {
+  width: float,
+  height: float,
+}
+and leftEarPosition = {
+  x: float,
+  y: float,
+}
+and rightEarPosition = {
+  x: float,
+  y: float,
+}
+and leftEyePosition = {
+  x: float,
+  y: float,
+}
+and rightEyePosition = {
+  x: float,
+  y: float,
+}
+and leftCheekPosition = {
+  x: float,
+  y: float,
+}
+and rightCheekPosition = {
+  x: float,
+  y: float,
+}
+and mouthPosition = {
+  x: float,
+  y: float,
+}
+and leftMouthPosition = {
+  x: float,
+  y: float,
+}
+and rightMouthPosition = {
+  x: float,
+  y: float,
+}
+and noseBasePosition = {
+  x: float,
+  y: float,
 };
 
 type faceDetectionMode =
@@ -190,13 +189,19 @@ type faceDetectionClassifications =
   | All
   | None;
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type barCodeScannerSettings = {
   barCodeTypes: array(string),
   useCamera2Api: bool,
 };
-
-let makeProps =
+type onBarCodeScanned = {
+  [@bs.as "type"]
+  _type: string,
+  data: string,
+};
+type onFacesDetected = {faces: array(face)};
+type message = string;
+let props =
     (
       ~type_: cameraType,
       ~flashMode: flashMode,
@@ -206,18 +211,12 @@ let makeProps =
       ~focusDepth: float,
       ~ratio: string,
       ~onCameraReady: unit => unit,
-      ~onFacesDetected: {. "faces": array(face)} => unit,
+      ~onFacesDetected: onFacesDetected => unit,
       ~faceDetectionMode: faceDetectionMode,
       ~faceDetectionLandmarks: faceDetectionLandmarks,
       ~faceDetectionClassifications: faceDetectionClassifications,
-      ~onMountError: {. "message": string} => unit,
-      ~onBarCodeScanned:
-         {
-           .
-           "type": string,
-           "data": string,
-         } =>
-         unit,
+      ~onMountError: message => unit,
+      ~onBarCodeScanned: onBarCodeScanned => unit,
       ~barCodeScannerSettings=?,
       ~style=?,
       ~children,
@@ -276,4 +275,4 @@ let makeProps =
 };
 
 [@bs.module "expo-camera"] [@react.component]
-external make: 'a => React.element = "Camera";
+external make: props => React.element = "Camera" /* external make: 'a => React.element = "Camera"*/;

--- a/packages/reason-expo/src/Camera.re
+++ b/packages/reason-expo/src/Camera.re
@@ -189,7 +189,6 @@ type faceDetectionClassifications =
   | All
   | None;
 
-// [@bs.deriving abstract]
 type barCodeScannerSettings = {
   barCodeTypes: array(string),
   useCamera2Api: bool,

--- a/packages/reason-expo/src/Contacts.re
+++ b/packages/reason-expo/src/Contacts.re
@@ -167,7 +167,7 @@ module CalendarFormats = {
   external islamic: t = "Islamic";
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type image = {
   uri: string,
   width: int,
@@ -175,7 +175,7 @@ type image = {
   base64: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type date = {
   day: int,
   month: int,
@@ -185,14 +185,14 @@ type date = {
   label: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type relationship = {
   name: string,
   id: string,
   label: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type email = {
   email: string,
   isPrimary: bool,
@@ -200,7 +200,7 @@ type email = {
   label: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type phoneNumber = {
   number: string,
   isPrimary: bool,
@@ -210,7 +210,7 @@ type phoneNumber = {
   label: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type address = {
   street: string,
   city: string,
@@ -224,19 +224,19 @@ type address = {
   label: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type group = {
   id: string,
   name: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type container = {
   id: string,
   name: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type socialProfile = {
   service: string,
   username: string,
@@ -247,7 +247,7 @@ type socialProfile = {
   label: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type instantMessageAddress = {
   service: string,
   username: string,
@@ -256,14 +256,14 @@ type instantMessageAddress = {
   label: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type urlAddress = {
   url: string,
   id: string,
   label: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type formOptions = {
   displayedPropertyKeys: array(Fields.t),
   message: string,
@@ -277,7 +277,7 @@ type formOptions = {
   preventAnimation: bool,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type contactQuery = {
   fields: array(Fields.t),
   pageSize: int,
@@ -290,21 +290,21 @@ type contactQuery = {
   rawContacts: bool,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type groupQuery = {
   groupName: string,
   groupId: string,
   containerId: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type containerQuery = {
   contactId: string,
   groupId: string,
   containerId: string,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type contact = {
   id: string,
   name: string,
@@ -338,7 +338,7 @@ type contact = {
   socialProfiles: array(socialProfile),
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type contactResponse = {
   data: array(contact),
   hasNextPage: bool,
@@ -346,61 +346,69 @@ type contactResponse = {
 };
 
 [@bs.module "expo-contacts"]
-external getContactsAsync: contactQuery => Js.Promise.t(contactResponse) = "";
+external getContactsAsync: contactQuery => Js.Promise.t(contactResponse) =
+  "getContactsAsync";
 
 [@bs.module "expo-contacts"]
 external getContactByIdAsync:
   (string, array(Fields.t)) => Js.Promise.t(contact) =
-  "";
+  "getContactByIdAsync";
 
 [@bs.module "expo-contacts"]
-external addContactAsync: (contact, string) => Js.Promise.t(string) = "";
+external addContactAsync: (contact, string) => Js.Promise.t(string) =
+  "getContactByIdAsync";
 
 [@bs.module "expo-contacts"]
-external updateContactAsync: contact => Js.Promise.t(string) = "";
+external updateContactAsync: contact => Js.Promise.t(string) =
+  "updateContactAsync";
 
 [@bs.module "expo-contacts"]
-external removeContactAsync: string => Js.Promise.t(unit) = "";
+external removeContactAsync: string => Js.Promise.t(unit) =
+  "removeContactAsync";
 
 [@bs.module "expo-contacts"]
-external writeContactToFileAsync: contactQuery => Js.Promise.t(string) = "";
+external writeContactToFileAsync: contactQuery => Js.Promise.t(string) =
+  "writeContactToFileAsync";
 
 [@bs.module "expo-contacts"]
 external presentFormAsync:
   (string, contact, formOptions) => Js.Promise.t(unit) =
-  "";
+  "presentFormAsync";
 
 [@bs.module "expo-contacts"]
 external addExistingGroupToContainerAsync:
   (string, string) => Js.Promise.t(unit) =
-  "";
+  "addExistingGroupToContainerAsync";
 
 [@bs.module "expo-contacts"]
 external createGroupAsync:
   (string, Js.Nullable.t(string)) => Js.Promise.t(string) =
-  "";
+  "createGroupAsync";
 
 [@bs.module "expo-contacts"]
-external updateGroupNameAsync: (string, string) => Js.Promise.t(unit) = "";
+external updateGroupNameAsync: (string, string) => Js.Promise.t(unit) =
+  "updateGroupNameAsync";
 
 [@bs.module "expo-contacts"]
-external removeGroupAsync: string => Js.Promise.t(unit) = "";
+external removeGroupAsync: string => Js.Promise.t(unit) = "removeGroupAsync";
 
 [@bs.module "expo-contacts"]
 external addExistingContactToGroupAsync:
   (string, string) => Js.Promise.t(unit) =
-  "";
+  "addExistingContactToGroupAsync";
 
 [@bs.module "expo-contacts"]
 external removeContactFromGroupAsync: (string, string) => Js.Promise.t(unit) =
-  "";
+  "removeContactFromGroupAsync";
 
 [@bs.module "expo-contacts"]
-external getGroupsAsync: groupQuery => Js.Promise.t(array(group)) = "";
+external getGroupsAsync: groupQuery => Js.Promise.t(array(group)) =
+  "getGroupsAsync";
 
 [@bs.module "expo-contacts"]
-external getDefaultContainerIdAsync: unit => Js.Promise.t(string) = "";
+external getDefaultContainerIdAsync: unit => Js.Promise.t(string) =
+  "getDefaultContainerIdAsync";
 
 [@bs.module "expo-contacts"]
 external getContainersAsync: containerQuery => Js.Promise.t(array(container)) =
-  "";
+  "getContainersAsync";

--- a/packages/reason-expo/src/Contacts.re
+++ b/packages/reason-expo/src/Contacts.re
@@ -167,7 +167,7 @@ module CalendarFormats = {
   external islamic: t = "Islamic";
 };
 
-// [@bs.deriving abstract]
+
 type image = {
   uri: string,
   width: int,
@@ -175,7 +175,7 @@ type image = {
   base64: string,
 };
 
-// [@bs.deriving abstract]
+
 type date = {
   day: int,
   month: int,
@@ -185,14 +185,14 @@ type date = {
   label: string,
 };
 
-// [@bs.deriving abstract]
+
 type relationship = {
   name: string,
   id: string,
   label: string,
 };
 
-// [@bs.deriving abstract]
+
 type email = {
   email: string,
   isPrimary: bool,
@@ -200,7 +200,7 @@ type email = {
   label: string,
 };
 
-// [@bs.deriving abstract]
+
 type phoneNumber = {
   number: string,
   isPrimary: bool,
@@ -210,7 +210,7 @@ type phoneNumber = {
   label: string,
 };
 
-// [@bs.deriving abstract]
+
 type address = {
   street: string,
   city: string,
@@ -224,19 +224,19 @@ type address = {
   label: string,
 };
 
-// [@bs.deriving abstract]
+
 type group = {
   id: string,
   name: string,
 };
 
-// [@bs.deriving abstract]
+
 type container = {
   id: string,
   name: string,
 };
 
-// [@bs.deriving abstract]
+
 type socialProfile = {
   service: string,
   username: string,
@@ -247,7 +247,7 @@ type socialProfile = {
   label: string,
 };
 
-// [@bs.deriving abstract]
+
 type instantMessageAddress = {
   service: string,
   username: string,
@@ -256,14 +256,14 @@ type instantMessageAddress = {
   label: string,
 };
 
-// [@bs.deriving abstract]
+
 type urlAddress = {
   url: string,
   id: string,
   label: string,
 };
 
-// [@bs.deriving abstract]
+
 type formOptions = {
   displayedPropertyKeys: array(Fields.t),
   message: string,
@@ -277,7 +277,7 @@ type formOptions = {
   preventAnimation: bool,
 };
 
-// [@bs.deriving abstract]
+
 type contactQuery = {
   fields: array(Fields.t),
   pageSize: int,
@@ -290,21 +290,21 @@ type contactQuery = {
   rawContacts: bool,
 };
 
-// [@bs.deriving abstract]
+
 type groupQuery = {
   groupName: string,
   groupId: string,
   containerId: string,
 };
 
-// [@bs.deriving abstract]
+
 type containerQuery = {
   contactId: string,
   groupId: string,
   containerId: string,
 };
 
-// [@bs.deriving abstract]
+
 type contact = {
   id: string,
   name: string,
@@ -338,7 +338,7 @@ type contact = {
   socialProfiles: array(socialProfile),
 };
 
-// [@bs.deriving abstract]
+
 type contactResponse = {
   data: array(contact),
   hasNextPage: bool,

--- a/packages/reason-expo/src/Crypto.re
+++ b/packages/reason-expo/src/Crypto.re
@@ -38,4 +38,4 @@ type cryptoDigestOptions = {encoding: CryptoEncoding.t};
 external digestStringAsync:
   (CryptoDigestAlgorithm.t, string, cryptoDigestOptions) =>
   Js.Promise.t(string) =
-  "";
+  "digestStringAsync";

--- a/packages/reason-expo/src/Crypto.re
+++ b/packages/reason-expo/src/Crypto.re
@@ -31,7 +31,6 @@ module CryptoEncoding = {
   external base64: t = "BASE64";
 };
 
-[@bs.deriving abstract]
 type cryptoDigestOptions = {encoding: CryptoEncoding.t};
 
 [@bs.module "expo-crypto"]

--- a/packages/reason-expo/src/DocumentPicker.re
+++ b/packages/reason-expo/src/DocumentPicker.re
@@ -1,20 +1,16 @@
-[@bs.deriving abstract]
+
 type options = {
   [@bs.as "type"]
   _type: string,
   copyToCacheDirectory: bool,
 };
 
-[@bs.deriving abstract]
 type result = {
   [@bs.as "type"]
   _type: string,
-  [@bs.optional]
-  uri: string,
-  [@bs.optional]
-  name: string,
-  [@bs.optional]
-  size: int,
+  uri: option(string),
+  name: option(string),
+  size: option(int),
 };
 
 [@bs.module "expo-document-picker"]

--- a/packages/reason-expo/src/FaceDetector.re
+++ b/packages/reason-expo/src/FaceDetector.re
@@ -32,13 +32,11 @@ module Constants = {
   };
 };
 
-// [@bs.deriving abstract]
 type point = {
   x: int,
   y: int,
 };
 
-// [@bs.deriving abstract]
 type faceFeature = {
   bounds,
   smilingProbability: Js.Nullable.t(float),
@@ -67,7 +65,6 @@ and size = {
   height: int,
 };
 
-// [@bs.deriving abstract]
 type detectionOptions = {
   mode: Js.Nullable.t(Constants.Mode.t),
   detectLandmarks: Js.Nullable.t(Constants.Landmarks.t),

--- a/packages/reason-expo/src/FaceDetector.re
+++ b/packages/reason-expo/src/FaceDetector.re
@@ -3,20 +3,20 @@ module Constants = {
     type t;
 
     [@bs.module "expo-face-detector"] [@bs.scope ("Constants", "Mode")]
-    external fast: t = "";
+    external fast: t = "fast";
 
     [@bs.module "expo-face-detector"] [@bs.scope ("Constants", "Mode")]
-    external accurate: t = "";
+    external accurate: t = "accurate";
   };
 
   module Landmarks = {
     type t;
 
     [@bs.module "expo-face-detector"] [@bs.scope ("Constants", "Landmarks")]
-    external all: t = "";
+    external all: t = "all";
 
     [@bs.module "expo-face-detector"] [@bs.scope ("Constants", "Landmarks")]
-    external none: t = "";
+    external none: t = "none";
   };
 
   module Classifications = {
@@ -24,31 +24,23 @@ module Constants = {
 
     [@bs.module "expo-face-detector"]
     [@bs.scope ("Constants", "Classifications")]
-    external all: t = "";
+    external all: t = "all";
 
     [@bs.module "expo-face-detector"]
     [@bs.scope ("Constants", "Classifications")]
-    external none: t = "";
+    external none: t = "none";
   };
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type point = {
   x: int,
   y: int,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type faceFeature = {
-  bounds: {
-    .
-    size: {
-      .
-      width: int,
-      height: int,
-    },
-    origin: point,
-  },
+  bounds,
   smilingProbability: Js.Nullable.t(float),
   leftEarPosition: Js.Nullable.t(point),
   rightEarPosition: Js.Nullable.t(point),
@@ -65,27 +57,33 @@ type faceFeature = {
   noseBasePosition: Js.Nullable.t(point),
   yawAngle: Js.Nullable.t(float),
   rollAngle: Js.Nullable.t(float),
+}
+and bounds = {
+  size,
+  origin: point,
+}
+and size = {
+  width: int,
+  height: int,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type detectionOptions = {
   mode: Js.Nullable.t(Constants.Mode.t),
   detectLandmarks: Js.Nullable.t(Constants.Landmarks.t),
   runClassifications: Js.Nullable.t(Constants.Classifications.t),
 };
-
+type detectFacesAsyncResponse = {
+  faces: array(faceFeature),
+  image,
+}
+and image = {
+  uri: string,
+  width: float,
+  height: float,
+  orientation: int,
+};
 [@bs.module "expo-face-detector"]
 external detectFacesAsync:
-  (string, detectionOptions) =>
-  Js.Promise.t({
-    .
-    "faces": array(faceFeature),
-    "image": {
-      .
-      "uri": string,
-      "width": float,
-      "height": float,
-      "orientation": int,
-    },
-  }) =
-  "";
+  (string, detectionOptions) => Js.Promise.t(detectFacesAsyncResponse) =
+  "detectFacesAsync";

--- a/packages/reason-expo/src/Facebook.re
+++ b/packages/reason-expo/src/Facebook.re
@@ -1,14 +1,10 @@
-[@bs.deriving abstract]
 type result = {
   [@bs.as "type"]
   _type: string,
-  [@bs.optional]
-  token: string,
-  [@bs.optional]
-  expires: string,
+  token: option(string),
+  expires: option(string),
 };
 
-[@bs.deriving abstract]
 type options = {
   permissions: array(string),
   behavior: string,

--- a/packages/reason-expo/src/FacebookAds.re
+++ b/packages/reason-expo/src/FacebookAds.re
@@ -15,34 +15,34 @@ module NativeAdsManager = {
 
 module InterstitialAdManager = {
   [@bs.module "expo-ads-facebook"] [@bs.scope "InterstitialAdManager"]
-  external showAd: string => Js.Promise.t(unit) = "";
+  external showAd: string => Js.Promise.t(unit) = "showAd";
 };
 
 module AdSettings = {
   [@bs.module "expo-ads-facebook"] [@bs.scope "AdSettings"]
-  external currentDeviceHash: string = "";
+  external currentDeviceHash: string = "currentDeviceHash";
 
   [@bs.module "expo-ads-facebook"] [@bs.scope "AdSettings"]
-  external addTestDevice: string => unit = "";
+  external addTestDevice: string => unit = "addTestDevice";
 
   [@bs.module "expo-ads-facebook"] [@bs.scope "AdSettings"]
-  external clearTestDevices: unit => unit = "";
+  external clearTestDevices: unit => unit = "clearTestDevices";
 
   [@bs.module "expo-ads-facebook"] [@bs.scope "AdSettings"]
-  external setLogLevel: string => unit = "";
+  external setLogLevel: string => unit = "setLogLevel";
 
   [@bs.module "expo-ads-facebook"] [@bs.scope "AdSettings"]
-  external setIsChildDirected: bool => unit = "";
+  external setIsChildDirected: bool => unit = "setIsChildDirected";
 
   [@bs.module "expo-ads-facebook"] [@bs.scope "AdSettings"]
-  external setMediationService: string => unit = "";
+  external setMediationService: string => unit = "setMediationService";
 
   [@bs.module "expo-ads-facebook"] [@bs.scope "AdSettings"]
-  external setUrlPrefix: string => unit = "";
+  external setUrlPrefix: string => unit = "setUrlPrefix";
 };
 
 [@bs.module "expo-ads-facebook"]
-external withNativeAd: React.element => React.element = "";
+external withNativeAd: React.element => React.element = "withNativeAd";
 
 module AdMediaView = {
   [@bs.module "expo-ads-facebook"] [@react.component]

--- a/packages/reason-expo/src/FileSystem.re
+++ b/packages/reason-expo/src/FileSystem.re
@@ -14,27 +14,20 @@ module EncodingTypes = {
   external base64: t = "Base64";
 };
 
-[@bs.deriving abstract]
+
 type fileInfo = {
   exists: bool,
-  [@bs.optional]
-  isDirectory: bool,
-  [@bs.optional]
-  modificationTime: int,
-  [@bs.optional]
-  size: int,
-  [@bs.optional]
-  uri: string,
-  [@bs.optional]
-  md5: string,
+  isDirectory: option(bool),
+  modificationTime: option(int),
+  size: option(int),
+  uri: option(string),
+  md5: option(string),
 };
 
-[@bs.deriving abstract]
+
 type getInfoAsyncOptions = {
-  [@bs.optional]
-  md5: bool,
-  [@bs.optional]
-  size: bool,
+  md5: option(bool),
+  size: option(bool),
 };
 
 [@bs.module "expo-file-system"]
@@ -53,17 +46,17 @@ external readAsStringAsync:
   (string, readAsStringAsyncOptions) => Js.Promise.t(string) =
   "readAsStringAsync";
 
-[@bs.deriving abstract]
+
 type writeAsStringAsyncOptions = {encoding: EncodingTypes.t};
 
 [@bs.module "expo-file-system"]
 external writeAsStringAsync: (string, string) => Js.Promise.t(unit) =
   "writeAsStringAsync";
 
-[@bs.deriving abstract]
+
 type deleteAsyncOptions = {
-  [@bs.optional]
-  idempotent: bool,
+
+  idempotent: option(bool),
 };
 
 [@bs.module "expo-file-system"]
@@ -124,13 +117,11 @@ external downloadAsync:
 module DownloadResumable = {
   type t = {.};
 
-  [@bs.deriving abstract]
   type downloadAsyncResult('headersType) = {
     uri: string,
     status: int,
     headers: 'headersType,
-    [@bs.optional]
-    md5: string,
+    md5: option(string),
   };
 
   [@bs.send]
@@ -138,7 +129,6 @@ module DownloadResumable = {
     (t, unit) => Js.Promise.t(downloadAsyncResult('headersType)) =
     "downloadAsync";
 
-  [@bs.deriving abstract]
   type pauseAsyncResult = {
     uri: string,
     fileUri: string,
@@ -150,13 +140,11 @@ module DownloadResumable = {
   external pauseAsync: (t, unit) => Js.Promise.t(pauseAsyncResult) =
     "pauseAsync";
 
-  [@bs.deriving abstract]
   type resumeAsyncResult('headersType) = {
     uri: string,
     status: int,
     headers: 'headersType,
-    [@bs.optional]
-    md5: string,
+    md5: option(string),
   };
 
   [@bs.send]
@@ -164,7 +152,6 @@ module DownloadResumable = {
     (t, unit) => Js.Promise.t(resumeAsyncResult('headersType)) =
     "resumeAsync";
 
-  [@bs.deriving abstract]
   type savableResult = {
     uri: string,
     fileUri: string,

--- a/packages/reason-expo/src/GLView.re
+++ b/packages/reason-expo/src/GLView.re
@@ -1,36 +1,32 @@
 [@bs.module "expo-gl"] [@bs.scope "GLView"]
-external createContextAsync: unit => Js.Promise.t('a) = "";
+external createContextAsync: unit => Js.Promise.t('a) = "createContextAsync";
 
 [@bs.module "expo-gl"] [@bs.scope "GLView"]
-external destroyContextAsync: 'a => Js.Promise.t(bool) = "";
-
+external destroyContextAsync: 'a => Js.Promise.t(bool) =
+  "destroyContextAsync";
+type takeSnapshotAsyncProps('a) = {
+  framebuffer: 'a,
+  rect,
+  flip: bool,
+  format: string,
+  compress: float,
+}
+and rect = {
+  x: float,
+  y: float,
+  height: float,
+  width: float,
+};
+type takeSnapshotAsyncResult = {
+  uri: string,
+  localUri: string,
+  width: float,
+  height: float,
+};
 [@bs.module "expo-gl"] [@bs.scope "GLView"]
 external takeSnapshotAsync:
-  (
-    'a,
-    {
-      .
-      framebuffer: 'a,
-      rect: {
-        .
-        x: float,
-        y: float,
-        height: float,
-        width: float,
-      },
-      flip: bool,
-      format: string,
-      compress: float,
-    }
-  ) =>
-  Js.Promise.t({
-    .
-    uri: string,
-    localUri: string,
-    width: float,
-    height: float,
-  }) =
-  "";
+  takeSnapshotAsyncProps('a) => Js.Promise.t(takeSnapshotAsyncResult) =
+  "takeSnapshotAsync";
 
 [@bs.module "expo-gl"] [@react.component]
 external make:

--- a/packages/reason-expo/src/Google.re
+++ b/packages/reason-expo/src/Google.re
@@ -1,18 +1,18 @@
-// [@bs.deriving abstract]
+
 type logInConfig = {
-  // [@bs.optional]
+
   iosClientId: option(string),
-  // [@bs.optional]
+
   androidClientId: option(string),
-  // [@bs.optional]
+
   iosStandaloneAppClientId: option(string),
-  // [@bs.optional]
+
   androidStandaloneAppClientId: option(string),
-  // [@bs.optional]
+
   scopes: option(array(string)),
-  // [@bs.optional]
+
   redirectUrl: option(string),
-  // [@bs.optional]
+
   mutable accessToken: option(string),
 };
 

--- a/packages/reason-expo/src/Google.re
+++ b/packages/reason-expo/src/Google.re
@@ -1,41 +1,57 @@
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type logInConfig = {
-  [@bs.optional]
-  iosClientId: string,
-  [@bs.optional]
-  androidClientId: string,
-  [@bs.optional]
-  iosStandaloneAppClientId: string,
-  [@bs.optional]
-  androidStandaloneAppClientId: string,
-  [@bs.optional]
-  scopes: array(string),
-  [@bs.optional]
-  redirectUrl: string,
-  [@bs.optional]
-  mutable accessToken: string,
+  // [@bs.optional]
+  iosClientId: option(string),
+  // [@bs.optional]
+  androidClientId: option(string),
+  // [@bs.optional]
+  iosStandaloneAppClientId: option(string),
+  // [@bs.optional]
+  androidStandaloneAppClientId: option(string),
+  // [@bs.optional]
+  scopes: option(array(string)),
+  // [@bs.optional]
+  redirectUrl: option(string),
+  // [@bs.optional]
+  mutable accessToken: option(string),
 };
 
 type logInResult = {
-  .
-  "_type": string,
-  "accessToken": string,
-  "idToken": string,
-  "refreshToken": string,
-  "user": googleUser,
+  [@bs.as "type"]
+  _type: string,
+  accessToken: string,
+  idToken: string,
+  refreshToken: string,
+  user: googleUser,
 }
 and googleUser = {
-  .
-  "id": string,
-  "name": string,
-  "givenName": string,
-  "familyName": string,
-  "photoUrl": string,
-  "email": string,
+  id: string,
+  name: string,
+  givenName: string,
+  familyName: string,
+  photoUrl: string,
+  email: string,
 };
+// type logInResult = {
+//   .
+//   "_type": string,
+//   "accessToken": string,
+//   "idToken": string,
+//   "refreshToken": string,
+//   "user": googleUser,
+// }
+// and googleUser = {
+//   .
+//   "id": string,
+//   "name": string,
+//   "givenName": string,
+//   "familyName": string,
+//   "photoUrl": string,
+//   "email": string,
+// };
 
 [@bs.module "expo-google-app-auth"]
-external logInAsync: logInConfig => Js.Promise.t(logInResult) = "";
+external logInAsync: logInConfig => Js.Promise.t(logInResult) = "logInAsync";
 
 [@bs.module "expo-google-app-auth"]
-external logOutAsync: logInConfig => Js.Promise.t('a) = "";
+external logOutAsync: logInConfig => Js.Promise.t('a) = "logOutAsync";

--- a/packages/reason-expo/src/ImageManipulator.re
+++ b/packages/reason-expo/src/ImageManipulator.re
@@ -1,43 +1,33 @@
-[@bs.deriving abstract]
 type action = {
-  [@bs.optional]
-  resize: {
-    .
+  resize:option(resize),
+  rotate: option(float),
+  flip:option(flip),
+  crop,
+} and resize = {
     width: float,
     height: float,
-  },
-  [@bs.optional]
-  rotate: float,
-  [@bs.optional]
-  flip: {
-    .
+  } and flip ={
+
     vertical: bool,
     horizontal: bool,
-  },
-  [@bs.optional]
-  crop: {
-    .
+  }and crop = {
     originX: float,
     originY: float,
     width: float,
     height: float,
-  },
-};
+  };
 
-[@bs.deriving abstract]
 type saveOptions = {
   compress: float,
   format: string,
   base64: bool,
 };
 
-[@bs.deriving abstract]
 type manipulateResult = {
   uri: string,
   width: float,
   height: float,
-  [@bs.optional]
-  base64: string,
+  base64: option(string),
 };
 
 [@bs.module "expo-image-manipulator"]

--- a/packages/reason-expo/src/ImagePicker.re
+++ b/packages/reason-expo/src/ImagePicker.re
@@ -7,7 +7,6 @@ module MediaTypeOptions = {
   external all: string = "all";
 };
 
-[@bs.deriving abstract]
 type launchImageLibraryAsyncOptions = {
   mediaTypes: string,
   allowsEditing: bool,
@@ -17,23 +16,16 @@ type launchImageLibraryAsyncOptions = {
   exif: bool,
 };
 
-[@bs.deriving abstract]
 type launchImageLibraryAsyncResult = {
   cancelled: bool,
-  [@bs.optional]
-  uri: string,
-  [@bs.optional]
-  width: float,
-  [@bs.optional]
-  height: float,
-  [@bs.optional] [@bs.as "type"]
-  _type: string,
-  [@bs.optional]
-  duration: float,
-  [@bs.optional]
-  base64: string,
-  [@bs.optional]
-  exif: string,
+  uri: option(string),
+  width: option(float),
+  height: option(float),
+  [@bs.as "type"]
+  _type: option(string),
+  duration: option(float),
+  base64: option(string),
+  exif: option(string),
 };
 
 [@bs.module "expo-image-picker"]
@@ -41,7 +33,6 @@ external launchImageLibraryAsync:
   launchImageLibraryAsyncOptions => launchImageLibraryAsyncResult =
   "launchImageLibraryAsync";
 
-[@bs.deriving abstract]
 type launchCameraAsyncOptions = {
   allowsEditing: bool,
   aspect: array(int),
@@ -50,21 +41,14 @@ type launchCameraAsyncOptions = {
   exif: bool,
 };
 
-[@bs.deriving abstract]
 type launchCameraAsyncResult = {
   cancelled: bool,
-  [@bs.optional]
-  uri: string,
-  [@bs.optional]
-  width: float,
-  [@bs.optional]
-  height: float,
-  [@bs.optional]
-  duration: float,
-  [@bs.optional]
-  base64: string,
-  [@bs.optional]
-  exif: string,
+  uri: option(string),
+  width: option(float),
+  height: option(float),
+  duration: option(float),
+  base64: option(string),
+  exif: option(string),
 };
 
 [@bs.module "expo-image-picker"]

--- a/packages/reason-expo/src/IntentLauncher.re
+++ b/packages/reason-expo/src/IntentLauncher.re
@@ -1,10 +1,7 @@
-[@bs.deriving abstract]
 type intentResult('extras) = {
   resultCode: int,
-  [@bs.optional]
-  data: string,
-  [@bs.optional]
-  extra: 'extras,
+  data: option(string),
+  extra: option('extras),
 };
 
 [@bs.module "expo-intent-launcher"]

--- a/packages/reason-expo/src/KeepAwake.re
+++ b/packages/reason-expo/src/KeepAwake.re
@@ -1,8 +1,8 @@
 [@bs.module "expo-keep-awake"]
-external useKeepAwake: Js.Nullable.t(string) => unit = "";
+external useKeepAwake: Js.Nullable.t(string) => unit = "useKeepAwake";
 
 [@bs.module "expo-keep-awake"]
-external activateKeepAwake: Js.Nullable.t(string) => unit = "";
+external activateKeepAwake: Js.Nullable.t(string) => unit = "activateKeepAwake";
 
 [@bs.module "expo-keep-awake"]
-external deactivateKeepAwake: Js.Nullable.t(string) => unit = "";
+external deactivateKeepAwake: Js.Nullable.t(string) => unit = "deactivateKeepAwake";

--- a/packages/reason-expo/src/Linking.re
+++ b/packages/reason-expo/src/Linking.re
@@ -1,22 +1,14 @@
 [@bs.module "expo"] [@bs.scope "Linking"]
-external makeUrl: (string, 'a) => string = "";
+external makeUrl: (string, 'a) => string = "makeUrl";
+
+type pathObject('a) = {
+  path: string,
+  queryParams: 'a,
+};
 
 [@bs.module "expo"] [@bs.scope "Linking"]
-external parse:
-  string =>
-  {
-    .
-    "path": string,
-    "queryParams": 'a,
-  } =
-  "";
+external parse: string => pathObject('a) = "parse";
 
 [@bs.module "expo"] [@bs.scope "Linking"]
-external parseInitialURLAsync:
-  unit =>
-  Js.Promise.t({
-    .
-    "path": string,
-    "queryParams": 'a,
-  }) =
-  "";
+external parseInitialURLAsync: unit => Js.Promise.t(pathObject('a)) =
+  "parseInitialURLAsync";

--- a/packages/reason-expo/src/LocalAuthentication.re
+++ b/packages/reason-expo/src/LocalAuthentication.re
@@ -19,18 +19,14 @@ external supportedAuthenticationTypesAsync:
 [@bs.module "expo-local-authentication"]
 external isEnrolledAsync: unit => Js.Promise.t(bool) = "isEnrolledAsync";
 
-[@bs.deriving abstract]
 type authenticateAsyncResult = {
   success: bool,
-  [@bs.optional]
-  error: string,
+  error: option(string),
 };
-[@bs.deriving abstract]
+
 type authenticateAsyncOptions = {
-  [@bs.optional]
-  promptMessage: string,
-  [@bs.optional]
-  fallbackLabel: string,
+  promptMessage: option(string),
+  fallbackLabel: option(string),
 };
 
 [@bs.module "expo-local-authentication"]

--- a/packages/reason-expo/src/Localization.re
+++ b/packages/reason-expo/src/Localization.re
@@ -1,15 +1,15 @@
-[@bs.module "expo-localization"] external locale: string = "";
+[@bs.module "expo-localization"] external locale: string = "locale";
 
-[@bs.module "expo-localization"] external locales: array(string) = "";
+[@bs.module "expo-localization"] external locales: array(string) = "locales";
 
-[@bs.module "expo-localization"] external country: Js.Nullable.t(string) = "";
+[@bs.module "expo-localization"] external country: Js.Nullable.t(string) = "country";
 
 [@bs.module "expo-localization"]
-external isoCurrencyCodes: Js.Nullable.t(array(string)) = "";
+external isoCurrencyCodes: Js.Nullable.t(array(string)) = "isoCurrencyCodes";
 
-[@bs.module "expo-localization"] external timezone: string = "";
+[@bs.module "expo-localization"] external timezone: string = "timezone";
 
-[@bs.module "expo-localization"] external isRTL: bool = "";
+[@bs.module "expo-localization"] external isRTL: bool = "isRTL";
 
 type localization = {
   locale: string,
@@ -21,4 +21,4 @@ type localization = {
 };
 
 [@bs.module "expo-localization"]
-external getLocalizationAsync: unit => Js.Promise.t(localization) = "";
+external getLocalizationAsync: unit => Js.Promise.t(localization) = "getLocalizationAsync";

--- a/packages/reason-expo/src/Location.re
+++ b/packages/reason-expo/src/Location.re
@@ -4,10 +4,10 @@ type eventSubscription;
 [@bs.send] external remove: (eventSubscription, unit) => unit = "remove";
 
 [@bs.module "expo-location"]
-external hasServicesEnabledAsync: unit => Js.Promise.t(bool) = "";
+external hasServicesEnabledAsync: unit => Js.Promise.t(bool) = "hasServicesEnabledAsync";
 
 [@bs.module "expo-location"]
-external requestPermissionsAsync: unit => Js.Promise.t(unit) = "";
+external requestPermissionsAsync: unit => Js.Promise.t(unit) = "requestPermissionsAsync";
 
 module Accuracy = {
   type t = int;
@@ -163,7 +163,7 @@ external reverseGeocodeAsync:
 [@bs.module "expo-location"] external setApiKey: string => unit = "setApiKey";
 
 [@bs.module "expo-location"]
-external installWebGeolocationPolyfill: unit => unit = "";
+external installWebGeolocationPolyfill: unit => unit = "installWebGeolocationPolyfill";
 
 [@bs.deriving abstract]
 type startLocationUpdatesAsyncOptions = {
@@ -176,13 +176,13 @@ type startLocationUpdatesAsyncOptions = {
 [@bs.module "expo-location"]
 external startLocationUpdatesAsync:
   (string, startLocationUpdatesAsyncOptions) => Js.Promise.t(unit) =
-  "";
+  "startLocationUpdatesAsync";
 
 [@bs.module "expo-location"]
-external stopLocationUpdatesAsync: string => Js.Promise.t(unit) = "";
+external stopLocationUpdatesAsync: string => Js.Promise.t(unit) = "stopLocationUpdatesAsync";
 
 [@bs.module "expo-location"]
-external hasStartedLocationUpdatesAsync: string => Js.Promise.t(bool) = "";
+external hasStartedLocationUpdatesAsync: string => Js.Promise.t(bool) = "hasStartedLocationUpdatesAsync";
 
 type geofencingRegion = {
   identifier: string,
@@ -196,9 +196,9 @@ type geofencingRegion = {
 [@bs.module "expo-location"]
 external startGeofencingAsync:
   (string, array(geofencingRegion)) => Js.Promise.t(unit) =
-  "";
+  "startGeofencingAsync";
 
 [@bs.module "expo-location"]
-external stopGeofencingAsync: string => Js.Promise.t(unit) = "";
+external stopGeofencingAsync: string => Js.Promise.t(unit) = "stopGeofencingAsync";
 [@bs.module "expo-location"]
-external hasStartedGeofencingAsync: string => Js.Promise.t(bool) = "";
+external hasStartedGeofencingAsync: string => Js.Promise.t(bool) = "hasStartedGeofencingAsync";

--- a/packages/reason-expo/src/MediaLibrary.re
+++ b/packages/reason-expo/src/MediaLibrary.re
@@ -2,46 +2,46 @@ module MediaType = {
   type t;
 
   [@bs.module "expo-media-library"] [@bs.scope "MediaType"]
-  external photo: t = "";
+  external photo: t = "photo";
 
   [@bs.module "expo-media-library"] [@bs.scope "MediaType"]
-  external video: t = "";
+  external video: t = "video";
 
   [@bs.module "expo-media-library"] [@bs.scope "MediaType"]
-  external audio: t = "";
+  external audio: t = "audio";
 
   [@bs.module "expo-media-library"] [@bs.scope "MediaType"]
-  external unknown: t = "";
+  external unknown: t = "unknown";
 };
 
 module SortBy = {
   type t;
 
   [@bs.module "expo-media-library"] [@bs.scope "SortBy"]
-  external default: t = "";
+  external default: t = "default";
 
-  [@bs.module "expo-media-library"] [@bs.scope "SortBy"] external id: t = "";
-
-  [@bs.module "expo-media-library"] [@bs.scope "SortBy"]
-  external creationTime: t = "";
+  [@bs.module "expo-media-library"] [@bs.scope "SortBy"] external id: t = "id";
 
   [@bs.module "expo-media-library"] [@bs.scope "SortBy"]
-  external modificationTime: t = "";
+  external creationTime: t = "creationTime";
 
   [@bs.module "expo-media-library"] [@bs.scope "SortBy"]
-  external mediaType: t = "";
+  external modificationTime: t = "modificationTime";
 
   [@bs.module "expo-media-library"] [@bs.scope "SortBy"]
-  external width: t = "";
+  external mediaType: t = "mediaType";
 
   [@bs.module "expo-media-library"] [@bs.scope "SortBy"]
-  external height: t = "";
+  external width: t = "width";
 
   [@bs.module "expo-media-library"] [@bs.scope "SortBy"]
-  external duration: t = "";
+  external height: t = "height";
+
+  [@bs.module "expo-media-library"] [@bs.scope "SortBy"]
+  external duration: t = "duration";
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type asset('exif) = {
   id: string,
   filename: string,
@@ -55,18 +55,17 @@ type asset('exif) = {
   mediaSubtypes: array(string),
   albumId: string,
   localUri: string,
-  location:
-    Js.Nullable.t({
-      .
-      latitude: float,
-      longitude: float,
-    }),
+  location: Js.Nullable.t(location),
   exif: 'exif,
   orientation: float,
   isFavorite: bool,
+}
+and location = {
+  latitude: float,
+  longitude: float,
 };
 
-[@bs.deriving abstract]
+// [@bs.deriving abstract]
 type album = {
   id: string,
   title: string,
@@ -75,17 +74,17 @@ type album = {
   type_: string,
   startTime: float,
   endTime: float,
-  approximateLocation:
-    Js.Nullable.t({
-      .
-      latitude: float,
-      longitude: float,
-    }),
+  approximateLocation: Js.Nullable.t(approximateLocation),
   locationNames: array(string),
+}
+and approximateLocation = {
+  latitude: float,
+  longitude: float,
 };
 
 [@bs.module "expo-media-library"]
-external createAssetAsync: string => Js.Promise.t(asset('exif)) = "";
+external createAssetAsync: string => Js.Promise.t(asset('exif)) =
+  "createAssetAsync";
 
 module AlbumOption = {
   type t = [ | `ID(string) | `Album(album)];
@@ -99,33 +98,31 @@ module AlbumOption = {
     | `Album(album) => rawSourceJS(album)
     };
 };
-
+type getAssetsAsyncProps = {
+  first: int,
+  after: string,
+  album: AlbumOption.rawSourceJS,
+  sortBy: array(SortBy.t),
+  mediaType: array(MediaType.t),
+};
+type getAssetsAsyncResponse('exif) = {
+  assets: array(asset('exif)),
+  endCursor: string,
+  hasNextPage: bool,
+  totalCount: int,
+};
 [@bs.module "expo-media-library"]
 external _getAssetsAsync:
-  {
-    .
-    "first": int,
-    "after": string,
-    "album": AlbumOption.rawSourceJS,
-    "sortBy": array(SortBy.t),
-    "mediaType": array(MediaType.t),
-  } =>
-  Js.Promise.t({
-    .
-    assets: array(asset('exif)),
-    endCursor: string,
-    hasNextPage: bool,
-    totalCount: int,
-  }) =
+  getAssetsAsyncProps => Js.Promise.t(getAssetsAsyncResponse('exif)) =
   "getAssetsAsync";
 
 let getAssetsAsync = (~first, ~after, ~album, ~sortBy, ~mediaType) =>
   _getAssetsAsync({
-    "first": first,
-    "after": after,
-    "album": AlbumOption.encodeSource(album),
-    "sortBy": sortBy,
-    "mediaType": mediaType,
+    first,
+    after,
+    album: AlbumOption.encodeSource(album),
+    sortBy,
+    mediaType,
   });
 
 module AssetOption = {
@@ -158,10 +155,12 @@ let deleteAssetsAsync = assets =>
   _deleteAssetsAsync(Array.map(a => AssetOption.encodeSource(a), assets));
 
 [@bs.module "expo-media-library"]
-external getAlbumsAsync: unit => Js.Promise.t(array(album)) = "";
+external getAlbumsAsync: unit => Js.Promise.t(array(album)) =
+  "getAlbumsAsync";
 
 [@bs.module "expo-media-library"]
-external getAlbumAsync: string => Js.Promise.t(Js.Nullable.t(album)) = "";
+external getAlbumAsync: string => Js.Promise.t(Js.Nullable.t(album)) =
+  "getAlbumAsync";
 
 [@bs.module "expo-media-library"]
 external _createAlbumAsync:
@@ -208,7 +207,8 @@ let removeAssetsFromAlbumAsync = (assets, albums) =>
   );
 
 [@bs.module "expo-media-library"]
-external getMomentsAsync: unit => Js.Promise.t(array(album)) = "";
+external getMomentsAsync: unit => Js.Promise.t(array(album)) =
+  "getMomentsAsync";
 
 class type eventSubscription =
   [@bs]
@@ -219,7 +219,7 @@ class type eventSubscription =
 [@bs.module "expo-media-library"]
 external addListener:
   ((array(asset('a)), array(asset('a))) => unit) => eventSubscription =
-  "";
+  "addListener";
 
 [@bs.module "expo-media-library"]
-external removeAllListeners: unit => unit = "";
+external removeAllListeners: unit => unit = "removeAllListeners";

--- a/packages/reason-expo/src/MediaLibrary.re
+++ b/packages/reason-expo/src/MediaLibrary.re
@@ -41,7 +41,7 @@ module SortBy = {
   external duration: t = "duration";
 };
 
-// [@bs.deriving abstract]
+
 type asset('exif) = {
   id: string,
   filename: string,
@@ -65,7 +65,7 @@ and location = {
   longitude: float,
 };
 
-// [@bs.deriving abstract]
+
 type album = {
   id: string,
   title: string,

--- a/packages/reason-expo/src/Notifications.re
+++ b/packages/reason-expo/src/Notifications.re
@@ -7,9 +7,9 @@ external addListener:
   (
     {
       .
-      "origin": string,
-      "data": Js.t({..}),
-      "remote": bool,
+      origin: string,
+      data: Js.t({..}),
+      remote: bool,
     } =>
     unit
   ) =>
@@ -53,58 +53,51 @@ external getBadgeNumberAsync: unit => Js.Promise.t(int) =
 external setBadgeNumberAsync: int => Js.Promise.t(unit) =
   "setBadgeNumberAsync";
 
+type gcmSenderId = string;
+type getDevicePushTokenAsyncResponse = {
+    [@bs.as "type"]
+    _type: string,
+    data: string,
+  };
 [@bs.module "expo"] [@bs.scope "Notifications"]
 external getDevicePushTokenAsync:
-  {. "gcmSenderId": string} =>
-  Js.Promise.t({
-    .
-    "type": string,
-    "data": string,
-  }) =
+  gcmSenderId =>
+  Js.Promise.t(getDevicePushTokenAsyncResponse) =
   "getDevicePushTokenAsync";
-
+type createCategoryAsyncProps = {
+  actionId: string,
+  buttonTitle: string,
+  textInput:
+    Js.Undefined.t({
+      .
+      submitButtonTitle: string,
+      placeholder: string,
+    }),
+  isDestructive: bool,
+  isAuthenticationRequired: bool,
+};
 [@bs.module "expo"] [@bs.scope "Notifications"]
 external createCategoryAsync:
-  (
-    string,
-    array({
-      .
-      "actionId": string,
-      "buttonTitle": string,
-      "textInput":
-        Js.Undefined.t({
-          .
-          "submitButtonTitle": string,
-          "placeholder": string,
-        }),
-      "isDestructive": bool,
-      "isAuthenticationRequired": bool,
-    })
-  ) =>
-  Js.Promise.t(unit) =
-  "";
+  (string, array(createCategoryAsyncProps)) => Js.Promise.t(unit) =
+  "createCategoryAsync";
 
 [@bs.module "expo"] [@bs.scope "Notifications"]
-external deleteCategoryAsync: string => Js.Promise.t(unit) = "";
+external deleteCategoryAsync: string => Js.Promise.t(unit) =
+  "deleteCategoryAsync";
 
-[@bs.deriving abstract]
 type channelAndroid = {
   name: string,
-  [@bs.optional]
-  description: string,
-  [@bs.optional]
-  sound: bool,
-  [@bs.optional]
-  priority: string,
-  [@bs.optional]
-  vibrate: array(int),
-  [@bs.optional]
-  badge: bool,
+  description: option(string),
+  sound: option(bool),
+  priority: option(string),
+  vibrate: option(array(int)),
+  badge: option(bool),
 };
 
 [@bs.module "expo"] [@bs.scope "Notifications"]
 external createChannelAndroidAsync:
   (string, channelAndroid) => Js.Promise.t(unit) =
-  "";
+  "createChannelAndroidAsync";
 [@bs.module "expo"] [@bs.scope "Notifications"]
-external deleteChannelAndroidAsync: string => Js.Promise.t(unit) = "";
+external deleteChannelAndroidAsync: string => Js.Promise.t(unit) =
+  "deleteChannelAndroidAsync";

--- a/packages/reason-expo/src/Pedometer.re
+++ b/packages/reason-expo/src/Pedometer.re
@@ -1,16 +1,16 @@
 [@bs.module "expo-sensors"] [@bs.scope "Pedometer"]
-external isAvailableAsync: unit => Js.Promise.t(bool) = "";
+external isAvailableAsync: unit => Js.Promise.t(bool) = "isAvailableAsync";
 
 [@bs.module "expo-sensors"] [@bs.scope "Pedometer"]
 external getStepCountAsync:
   (Js.Date.t, Js.Date.t) => Js.Promise.t({. steps: int}) =
-  "";
+  "getStepCountAsync";
 
 class type eventSubscription =
   [@bs]
   {
     pub remove: unit => unit;
   };
-
+type steps = {steps: int};
 [@bs.module "expo-sensors"] [@bs.scope "Pedometer"]
-external watchStepCount: ({. steps: int} => unit) => eventSubscription = "";
+external watchStepCount: (steps => unit) => eventSubscription = "watchStepCount";

--- a/packages/reason-expo/src/Print.re
+++ b/packages/reason-expo/src/Print.re
@@ -8,7 +8,6 @@ module Orientation = {
   external landscape: t = "landscape";
 };
 
-[@bs.deriving abstract]
 type printAsyncOptions = {
   uri: string,
   html: string,
@@ -21,7 +20,6 @@ type printAsyncOptions = {
 [@bs.module "expo-print"]
 external printAsync: printAsyncOptions => Js.Promise.t(unit) = "printAsync";
 
-[@bs.deriving abstract]
 type printToFileAsyncOptions = {
   html: string,
   width: float,
@@ -29,12 +27,11 @@ type printToFileAsyncOptions = {
   base64: bool,
 };
 
-[@bs.deriving abstract]
+
 type printToFileAsyncResult = {
   uri: string,
   numberOfPages: int,
-  [@bs.optional]
-  base64: string,
+  base64: option(string),
 };
 
 [@bs.module "expo-print"]
@@ -42,7 +39,7 @@ external printToFileAsync:
   printToFileAsyncOptions => Js.Promise.t(printToFileAsyncResult) =
   "printToFileAsync";
 
-[@bs.deriving abstract]
+
 type selectPrinterAsyncResult = {
   name: string,
   url: string,

--- a/packages/reason-expo/src/Random.re
+++ b/packages/reason-expo/src/Random.re
@@ -1,3 +1,3 @@
 [@bs.module "expo-random"]
 external getRandomBytesAsync: int => Js.Promise.t(Js.Typed_array.Uint8Array.t) =
-  "";
+  "getRandomBytesAsync";

--- a/packages/reason-expo/src/SQLite.re
+++ b/packages/reason-expo/src/SQLite.re
@@ -23,14 +23,12 @@
 module Transaction = {
   type t;
 
-  [@bs.deriving abstract]
   type resultSetRows('row) = {
     length: string,
     item: int => 'row,
     _array: array('row),
   };
 
-  [@bs.deriving abstract]
   type resultSet('row) = {
     insertId: int,
     rowsAffected: int,

--- a/packages/reason-expo/src/SQLite.rei
+++ b/packages/reason-expo/src/SQLite.rei
@@ -1,14 +1,12 @@
 module Transaction: {
   type t;
 
-  [@bs.deriving abstract]
   type resultSetRows('row) = {
     length: string,
     item: int => 'row,
     _array: array('row),
   };
 
-  [@bs.deriving abstract]
   type resultSet('row) = {
     insertId: int,
     rowsAffected: int,

--- a/packages/reason-expo/src/ScreenOrientation.re
+++ b/packages/reason-expo/src/ScreenOrientation.re
@@ -98,28 +98,25 @@ module WebOrientationLock = {
   external unknown: t = "UNKNOWN";
 };
 
-[@bs.deriving abstract]
 type platformOrientationInfo = {
   screenOrientationConstantAndroid: int,
   screenOrientationArrayIOS: array(Orientation.t),
   screenOrientationLockWebOrientation: WebOrientationLock.t,
 };
 
-[@bs.deriving abstract]
 type orientationInfo = {
   orientation: Orientation.t,
   verticalSizeClass: SizeClassIOS.t,
   horizontalSizeClass: SizeClassIOS.t,
 };
 
-[@bs.deriving abstract]
 type orientationChangeEvent = {
   orientationLock: OrientationLock.t,
   orientationInfo,
 };
 
 module Subscription = {
-  [@bs.deriving abstract]
+
   type t;
 
   [@bs.send] external remove: (t, unit) => unit = "remove";
@@ -128,38 +125,38 @@ module Subscription = {
 type orientationChangeListener = orientationChangeEvent => unit;
 
 [@bs.module "expo"] [@bs.scope "ScreenOrientation"]
-external allowAsync: OrientationLock.t => Js.Promise.t(unit) = "";
+external allowAsync: OrientationLock.t => Js.Promise.t(unit) = "allowAsync";
 
 [@bs.module "expo"] [@bs.scope "ScreenOrientation"]
-external lockAsync: OrientationLock.t => Js.Promise.t(unit) = "";
+external lockAsync: OrientationLock.t => Js.Promise.t(unit) = "lockAsync";
 
 [@bs.module "expo"] [@bs.scope "ScreenOrientation"]
 external lockPlatformAsync: platformOrientationInfo => Js.Promise.t(unit) =
-  "";
+  "lockPlatformAsync";
 
 [@bs.module "expo"] [@bs.scope "ScreenOrientation"]
-external unlockAsync: unit => Js.Promise.t(unit) = "";
+external unlockAsync: unit => Js.Promise.t(unit) = "unlockAsync";
 
 [@bs.module "expo"] [@bs.scope "ScreenOrientation"]
 external getOrientationLockAsync: unit => Js.Promise.t(OrientationLock.t) =
-  "";
+  "getOrientationLockAsync";
 
 [@bs.module "expo"] [@bs.scope "ScreenOrientation"]
 external getPlatformOrientationLockAsync:
   unit => Js.Promise.t(platformOrientationInfo) =
-  "";
+  "getPlatformOrientationLockAsync";
 
 [@bs.module "expo"] [@bs.scope "ScreenOrientation"]
 external supportsOrientationLockAsync: OrientationLock.t => Js.Promise.t(bool) =
-  "";
+  "supportsOrientationLockAsync";
 
 [@bs.module "expo"] [@bs.scope "ScreenOrientation"]
 external addOrientationChangeListener:
   orientationChangeListener => Subscription.t =
-  "";
+  "addOrientationChangeListener";
 
 [@bs.module "expo"] [@bs.scope "ScreenOrientation"]
-external removeOrientationChangeListeners: unit => unit = "";
+external removeOrientationChangeListeners: unit => unit = "removeOrientationChangeListeners";
 
 [@bs.module "expo"] [@bs.scope "ScreenOrientation"]
-external removeOrientationChangeListener: Subscription.t => unit = "";
+external removeOrientationChangeListener: Subscription.t => unit = "removeOrientationChangeListener";

--- a/packages/reason-expo/src/Sharing.re
+++ b/packages/reason-expo/src/Sharing.re
@@ -1,4 +1,3 @@
-[@bs.deriving abstract]
 type shareAsyncOptions = {
   mimeType: string,
   dialogTitle: string,
@@ -7,4 +6,4 @@ type shareAsyncOptions = {
 };
 
 [@bs.module "expo-sharing"]
-external shareAsync: (string, shareAsyncOptions) => Js.Promise.t(unit) = "";
+external shareAsync: (string, shareAsyncOptions) => Js.Promise.t(unit) = "shareAsync";

--- a/packages/reason-expo/src/Static.re
+++ b/packages/reason-expo/src/Static.re
@@ -1,7 +1,6 @@
 [@bs.module "expo"]
-external registerRootComponent: ('a => React.element) => unit = "";
+external registerRootComponent: ('a => React.element) => unit = "registerRootComponent";
 
-[@bs.deriving abstract]
 type takeSnapshotAsyncOptions = {
   format: string,
   quality: float,
@@ -13,4 +12,4 @@ type takeSnapshotAsyncOptions = {
 [@bs.module "expo"]
 external takeSnapshotAsync:
   (React.Ref.t(React.element), takeSnapshotAsyncOptions) => unit =
-  "";
+  "takeSnapshotAsync";

--- a/packages/reason-expo/src/TaskManager.re
+++ b/packages/reason-expo/src/TaskManager.re
@@ -1,27 +1,31 @@
 [@bs.module "expo-task-manager"]
-external defineTask: (string, 'a => unit) => unit = "";
+external defineTask: (string, 'a => unit) => unit = "defineTask";
 
 [@bs.module "expo-task-manager"]
-external isTaskRegisteredAsync: string => Js.Promise.t(bool) = "";
+external isTaskRegisteredAsync: string => Js.Promise.t(bool) =
+  "isTaskRegisteredAsync";
 
 [@bs.module "expo-task-manager"]
-external getTaskOptionsAsync: string => Js.Promise.t('a) = "";
+external getTaskOptionsAsync: string => Js.Promise.t('a) =
+  "getTaskOptionsAsync";
 
+type getTasgetRegisteredTasksAsyncResponse('a) = {
+  taskName: string,
+  taskType: string,
+  options: 'a,
+};
 [@bs.module "expo-task-manager"]
 external getTasgetRegisteredTasksAsync:
   unit =>
   Js.Promise.t(
-    array({
-      .
-      taskName: string,
-      taskType: string,
-      options: 'a,
-    }),
+    array(getTasgetRegisteredTasksAsyncResponse('a)),
   ) =
-  "";
+  "getTasgetRegisteredTasksAsync";
 
 [@bs.module "expo-task-manager"]
-external unregisterTaskAsync: string => Js.Promise.t(unit) = "";
+external unregisterTaskAsync: string => Js.Promise.t(unit) =
+  "unregisterTaskAsync";
 
 [@bs.module "expo-task-manager"]
-external unregisterAllTasksAsync: unit => Js.Promise.t(unit) = "";
+external unregisterAllTasksAsync: unit => Js.Promise.t(unit) =
+  "unregisterAllTasksAsync";

--- a/packages/reason-expo/src/Updates.re
+++ b/packages/reason-expo/src/Updates.re
@@ -10,16 +10,14 @@ type updateFetchResult('manifestType) = {
   manifest: 'manifestType,
 };
 
-[@bs.deriving abstract]
+
 type event('manifestType) = {
   [@bs.as "type"]
   _type: string,
   manifest: 'manifestType,
-  [@bs.optional]
-  message: string,
+  message: option(string),
 };
 
-[@bs.deriving abstract]
 type eventSubscription;
 
 [@bs.send] external remove: (eventSubscription, unit) => unit = "remove";

--- a/packages/reason-expo/src/Video.re
+++ b/packages/reason-expo/src/Video.re
@@ -24,42 +24,25 @@ module PosterSource = {
   external fromRequired: ReactNative.Packager.required => t = "%identity";
 };
 
-[@bs.deriving abstract]
 type playbackStatus = {
   isLoaded: bool,
-  [@bs.optional]
-  error: string,
-  [@bs.optional]
-  uri: string,
-  [@bs.optional]
-  progressUpdateIntervalMillis: int,
-  [@bs.optional]
-  durationMillis: int,
-  [@bs.optional]
-  positionMillis: int,
-  [@bs.optional]
-  playableDurationMillis: int,
-  [@bs.optional]
-  shouldPlay: bool,
-  [@bs.optional]
-  isPlaying: bool,
-  [@bs.optional]
-  isBuffering: bool,
-  [@bs.optional]
-  rate: float,
-  [@bs.optional]
-  shouldCorrectPitch: bool,
-  [@bs.optional]
-  volume: float,
-  [@bs.optional]
-  isMuted: bool,
-  [@bs.optional]
-  isLooping: bool,
-  [@bs.optional]
-  didJustFinish: bool,
+  error: option(string),
+  uri: option(string),
+  progressUpdateIntervalMillis: option(int),
+  durationMillis: option(int),
+  positionMillis: option(int),
+  playableDurationMillis: option(int),
+  shouldPlay: option(bool),
+  isPlaying: option(bool),
+  isBuffering: option(bool),
+  rate: option(float),
+  shouldCorrectPitch: option(bool),
+  volume: option(float),
+  isMuted: option(bool),
+  isLooping: option(bool),
+  didJustFinish: option(bool),
 };
 
-[@bs.deriving abstract]
 type onReadyForDisplayParam = {
   naturalSize: {
     .
@@ -70,7 +53,6 @@ type onReadyForDisplayParam = {
   status: playbackStatus,
 };
 
-[@bs.deriving abstract]
 type onFullscreenUpdateParam = {
   fullscreenUpdate: int,
   status: playbackStatus,

--- a/packages/reason-expo/src/VideoThumbnails.re
+++ b/packages/reason-expo/src/VideoThumbnails.re
@@ -1,11 +1,9 @@
-[@bs.deriving abstract]
 type getThumbnailAsyncOptions('headers) = {
   compress: float,
   time: int,
   headers: 'headers,
 };
 
-[@bs.deriving abstract]
 type getThumbnailAsyncResult = {
   uri: string,
   height: float,
@@ -16,4 +14,4 @@ type getThumbnailAsyncResult = {
 external getThumbnailAsync:
   (string, getThumbnailAsyncOptions('headers)) =>
   Js.Promise.t(getThumbnailAsyncResult) =
-  "";
+  "getThumbnailAsync";

--- a/packages/reason-expo/src/WebBrowser.re
+++ b/packages/reason-expo/src/WebBrowser.re
@@ -1,28 +1,20 @@
-[@bs.deriving abstract]
 type openBrowserAsyncResult = {
   [@bs.as "type"]
   _type: string,
 };
 
-[@bs.deriving abstract]
 type openBrowserAsyncOptions = {
-  [@bs.optional]
-  toolbarColor: string,
-  [@bs.optional]
-  collapseToolbar: bool,
-  [@bs.optional]
-  controlsColor: string,
-  [@bs.optional]
-  showTitle: bool,
-  [@bs.optional]
-  package: string,
+  toolbarColor: option(string),
+  collapseToolbar: option(bool),
+  controlsColor: option(string),
+  showTitle: option(bool),
+  package: option(string),
 };
 
 [@bs.module "expo-web-browser"]
 external openBrowserAsync: string => Js.Promise.t(openBrowserAsyncResult) =
   "openBrowserAsync";
 
-[@bs.deriving abstract]
 type openAuthSessionAsyncResult = {
   [@bs.as "type"]
   _type: string,
@@ -43,7 +35,6 @@ type warmUpAsyncResult = {package: string};
 external warmUpAsync: string => Js.Promise.t(warmUpAsyncResult) =
   "warmUpAsync";
 
-[@bs.deriving abstract]
 type mayInitWithUrlAsyncResult = {package: string};
 
 [@bs.module "expo-web-browser"]
@@ -51,14 +42,12 @@ external mayInitWithUrlAsync:
   (string, string) => Js.Promise.t(mayInitWithUrlAsyncResult) =
   "mayInitWithUrlAsync";
 
-[@bs.deriving abstract]
 type coolDownAsyncResult = {package: string};
 
 [@bs.module "expo-web-browser"]
 external coolDownAsync: string => Js.Promise.t(coolDownAsyncResult) =
   "coolDownAsync";
 
-[@bs.deriving abstract]
 type dismissBrowserResult = {
   [@bs.as "type"]
   _type: string,
@@ -68,14 +57,11 @@ type dismissBrowserResult = {
 external dismissBrowser: unit => Js.Promise.t(dismissBrowserResult) =
   "dismissBrowser";
 
-[@bs.deriving abstract]
 type getCustomTabsSupportingBrowsersResult = {
   browserPackages: array(string),
-  [@bs.optional]
-  defaultBrowserPackage: string,
+  defaultBrowserPackage: option(string),
   servicePackages: array(string),
-  [@bs.optional]
-  preferredBrowserPackage: string,
+  preferredBrowserPackage: option(string),
 };
 
 [@bs.module "expo-web-browser"]

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -11,7 +11,7 @@
     "watch": "bsb -make-world -clean-world -w"
   },
   "dependencies": {
-    "bs-platform": "^5.0.4",
+    "bs-platform": "^7.0.1",
     "reason-react-native": "^0.60.0",
     "expo": "^34.0.3",
     "expo-linear-gradient": "^5.0.1",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "babel-preset-expo": "^6.0.0",
-    "bs-platform": "^5.0.6",
+    "bs-platform": "^7.0.1",
     "expo-yarn-workspaces": "^1.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1317,15 +1317,10 @@ browserslist@^4.6.0, browserslist@^4.6.2:
     electron-to-chromium "^1.3.164"
     node-releases "^1.1.23"
 
-bs-platform@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"
-  integrity sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ==
-
-bs-platform@^5.0.6:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.6.tgz#88c13041fb020479800de3d82c680bf971091425"
-  integrity sha512-6Boa2VEcWJp2WJr38L7bp3J929nYha7gDarjxb070jWzgfPJ/WbzjipmSfnu2eqqk1MfjEIpBipbPz6n1NISwA==
+bs-platform@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.0.1.tgz#1d7b0ef6088b998dceee5db74a7cd8f01c20a3bd"
+  integrity sha512-UjStdtHhbtC/l6vKJ1XRDqrPk7rFf5PLYHtRX3akDXEYVnTbN36z0g4DEr5mU8S0N945e33HYts9x+i7hKKpZQ==
 
 bser@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
I have updated the package to `bs-platform@7.0.1`. There maybe a few places where we could remove the `.` notations where `js` objects are inlined, example in `AR.re` https://github.com/idkjs/reason-expo/blob/0e7a1f87eb6adbcbeb216b52667b8105179558dd/packages/reason-expo/src/AR.re#L522-L566

Not sure if the tests need to be adjusted. As of now, they all pass as is.

I have add new usage comments at the top of `AuthSession.re`. The old ones will have to be removed once accepted. https://github.com/idkjs/reason-expo/blob/e492bd72c98b7c4ca3bbc15a99d8da716d531359/packages/reason-expo/src/AuthSession.re#L14-L22

Looking forward you your feedback to see how to proceed.

Peace/Love.