### PR TITLE
Fix Sqlite scope

### DIFF
--- a/packages/reason-expo/src/SQLite.re
+++ b/packages/reason-expo/src/SQLite.re
@@ -84,5 +84,5 @@ module Database = {
     "transaction";
 };
 
-[@bs.module "expo-sqlite"] [@bs.scope "SQLite"]
+[@bs.module "expo-sqlite"]
 external openDatabase: string => Database.t = "openDatabase";


### PR DESCRIPTION
When using `SQLite` with the demo code, 

```reason
open Expo.SQLite;
    
    let db = openDatabase("db.db");

    Database.transaction(
        db,
        t =>
            Transaction.(
            executeSql(
                t,
                "SELECT * FROM ingredients",
                [`String("A string argument"), `Float(3.)],
                (_transaction, rs: resultSet({..})) => Js.log(rs),
                (_transaction, error) => Js.log(error),
            )
            )
            |> ignore,
        (_) => (),
        () => (),
    );
```

we encountered this error at runtime

```
TypeError: TypeError: undefined is not an object (evaluating 'ExpoSqlite.SQLite.openDatabase')
- node_modules/reason-expo/src/SQLite.bs.js:29:27 in openDatabase
```

The scope was useless. I fixed it.
