### PR TITLE
Removes `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.re linguist-language=OCaml
-*.rei linguist-language=OCaml


### PR DESCRIPTION
GitHub recognizes ReasonML as a valid programming language/file type now, so we can omit `.gitattributes` which currently forces GH to recognize it as Ocaml (where beforehand it would sometimes mistake it for C/C++).